### PR TITLE
Added missing SND_SEQ_EVENT_CLOCK event (MIDI Real Time Clock message) f...

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1210,6 +1210,10 @@ extern "C" void *alsaMidiHandler( void *ptr )
       if ( !( data->ignoreFlags & 0x02 ) ) doDecode = true;
       break;
 
+    case SND_SEQ_EVENT_CLOCK: // MIDI timing clock
+      if ( !( data->ignoreFlags & 0x02 ) ) doDecode = true;
+      break;
+
     case SND_SEQ_EVENT_SENSING: // Active sensing
       if ( !( data->ignoreFlags & 0x04 ) ) doDecode = true;
       break;


### PR DESCRIPTION
...or timing ignoring.

The event ignoring mechanism is missing SND_SEQ_EVENT_CLOCK from ALSA, which is the event type associated with the MIDI message 0xF8 (Timing Clock). The used SND_SEQ_EVENT_TICK event is not an outside world MIDI message, but a special message generated by the ALSA synth.

I discovered this bug when working with a real Yamaha Clavinova Digital Piano, which was broadcasting 0xF8 messages and RtMidi wasn't properly ignoring them. This proposed patch correctly ignores that message, like the other drivers inside RtMidi.
