### PR TITLE
Fix null conversion warning

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -653,7 +653,7 @@ CFStringRef EndpointName( MIDIEndpointRef endpoint, bool isExternal )
     CFRelease( str );
   }
 
-  MIDIEntityRef entity = NULL;
+  MIDIEntityRef entity = 0;
   MIDIEndpointGetEntity( endpoint, &entity );
   if ( entity == 0 )
     // probably virtual


### PR DESCRIPTION
On OS X compiling generates a warning:

```
andrew@humming:~/tmp/rtmidi% make
g++ -O3 -Wall -Iinclude -fPIC -INONE/include  -D__MACOSX_CORE__ -c RtMidi.cpp -o RtMidi.o
RtMidi.cpp:656:26: warning: implicit conversion of NULL constant to 'MIDIEntityRef' (aka 'unsigned int') [-Wnull-conversion]
  MIDIEntityRef entity = NULL;
                ~~~~~~   ^~~~
                         0
1 warning generated.
```
