### PR TITLE
Add sequence number also to MIDI sink names.

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1716,6 +1716,8 @@ std::string MidiOutAlsa :: getPortName( unsigned int portNumber )
     snd_seq_get_any_client_info( data->seq, cnum, cinfo );
     std::ostringstream os;
     os << snd_seq_client_info_get_name(cinfo);
+    os << " ";                                    // GO: These lines added to make sure devices are listed
+    os << snd_seq_port_info_get_client( pinfo );  // GO: with full portnames added to ensure individual device names
     os << ":";
     os << snd_seq_port_info_get_port(pinfo);
     stringName = os.str();


### PR DESCRIPTION
As already discussed in another pull request https://github.com/thestk/rtmidi/pull/6 ALSA gets unmanagable if we use the currently provided RtMidi enumeration ids as these have many issues with race conditions while other devices or clients add ports. So far, ports can only be reliably destinguished by their names. This patch adds the port number to output devices so that they also have unique names and naming is consistent with input devices.
