### PR TITLE
Save correct input port after creation.

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1571,12 +1571,17 @@ void MidiInAlsa :: openVirtualPort( std::string portName )
     snd_seq_port_info_set_timestamp_queue(pinfo, data->queue_id);
 #endif
     snd_seq_port_info_set_name(pinfo, portName.c_str());
-    data->vport = snd_seq_create_port(data->seq, pinfo);
+    int createok = snd_seq_create_port(data->seq, pinfo);
 
-    if ( data->vport < 0 ) {
+    if ( createok < 0 ) {
       errorString_ = "MidiInAlsa::openVirtualPort: ALSA error creating virtual port.";
       RtMidi::error( RtError::DRIVER_ERROR, errorString_ );
+      data->vport = createok;
+    } else {
+	    data->vport = snd_seq_port_info_get_port(pinfo);
     }
+
+    data->vport = snd_seq_create_port(data->seq, pinfo);
   }
 
   if ( inputData_.doInput == false ) {


### PR DESCRIPTION
snd_seq_create_port returns always 0 on success. Even if the port number is actually different.

The patch allows to handle more than one input device.
