### PR TITLE
Improve diagnostics when ALSA reports an unexpected error.

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1180,7 +1180,8 @@ extern "C" void *alsaMidiHandler( void *ptr )
       continue;
     }
     else if ( result <= 0 ) {
-      std::cerr << "MidiInAlsa::alsaMidiHandler: unknown MIDI input error!\n";
+      std::cerr << "\nMidiInAlsa::alsaMidiHandler: unknown MIDI input error!\n";
+      perror("System reports");
       continue;
     }
 


### PR DESCRIPTION
In certain rare cases you get other errors than input buffer overruns. perror should provide some limited diagnostic information in these cases. As I don't know how to reproduce the issue I could not test this patch.
