### PR TITLE
Fix packet list size for CoreMidi

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1062,7 +1062,7 @@ void MidiOutCore :: sendMessage( std::vector<unsigned char> *message )
 
   MIDIPacketList packetList;
   MIDIPacket *packet = MIDIPacketListInit( &packetList );
-  packet = MIDIPacketListAdd( &packetList, sizeof(packetList), packet, timeStamp, nBytes, (const Byte *) &message->at( 0 ) );
+  packet = MIDIPacketListAdd( &packetList, nBytes*sizeof(packet), packet, timeStamp, nBytes, (const Byte *) &message->at( 0 ) );
   if ( !packet ) {
     errorString_ = "MidiOutCore::sendMessage: could not allocate packet list";      
     error( RtMidiError::DRIVER_ERROR, errorString_ );


### PR DESCRIPTION
During the course of writing a sysex router using RtMidi I came across some packet sizes in excess of 64 bytes that caused an error.  This patch fixes that, and I believe my interpretation of the altered parameter is correct as opposed to what is currently in trunk.
