### PR TITLE
added ALSA port deletion on close

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1645,6 +1645,9 @@ void MidiInAlsa :: closePort( void )
       snd_seq_port_subscribe_free( data->subscription );
       data->subscription = 0;
     }
+    snd_seq_delete_port( data->seq, data->vport );
+    data->vport = -1;
+
     // Stop the input queue
 #ifndef AVOID_TIMESTAMPING
     snd_seq_stop_queue( data->seq, data->queue_id, NULL );
@@ -1835,6 +1838,8 @@ void MidiOutAlsa :: closePort( void )
     AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
     snd_seq_unsubscribe_port( data->seq, data->subscription );
     snd_seq_port_subscribe_free( data->subscription );
+    snd_seq_delete_port( data->seq, data->vport );
+    data->vport = -1;
     connected_ = false;
   }
 }


### PR DESCRIPTION
Hello,
I found out that the ALSA code does not cleanup the MIDI "ALSA port" when closing input or output midi ports. An easy way to reproduce a bug is to create a MIDI input object, then open a MIDI input port, close it and try to re-use the object to open another (or the same) MIDI input port. It will fail with an operation not permitted error. The reason is that the closePort() code does not delete the underlying ALSA port. I fixed this in this Pull Request (aimed for version 2.1.0, not the current development). I tested it without a problem on my local Linux machine.

I hope we can see fixed 2.1.1 version :)

Cheers,
Hugo.