### PR TITLE
fix virtual ports closing in OSX

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -667,11 +667,17 @@ void MidiInCore :: openVirtualPort( const std::string portName )
 
 void MidiInCore :: closePort( void )
 {
-  if ( connected_ ) {
-    CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
-    MIDIPortDispose( data->port );
-    connected_ = false;
+  CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
+
+  if ( data->endpoint ) {
+    MIDIEndpointDispose( data->endpoint );
   }
+
+  if ( data->port ) {
+    MIDIPortDispose( data->port );
+  }
+
+  connected_ = false;
 }
 
 unsigned int MidiInCore :: getPortCount()

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -956,11 +956,17 @@ void MidiOutCore :: openPort( unsigned int portNumber, const std::string portNam
 
 void MidiOutCore :: closePort( void )
 {
-  if ( connected_ ) {
-    CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
-    MIDIPortDispose( data->port );
-    connected_ = false;
+  CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
+
+  if ( data->endpoint ) {
+    MIDIEndpointDispose( data->endpoint );
   }
+
+  if ( data->port ) {
+    MIDIPortDispose( data->port );
+  }
+
+  connected_ = false;
 }
 
 void MidiOutCore :: openVirtualPort( std::string portName )


### PR DESCRIPTION
Without this they still "hang around" even after being closed, references:

- https://github.com/justinlatimer/node-midi/pull/96
- https://github.com/justinlatimer/node-midi/issues/75