### PR TITLE
Add autogen.sh script

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# Run this to generate all the initial makefiles, etc.
+
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+DIE=0
+
+(test -f $srcdir/configure.ac) || {
+    echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
+    echo " top-level package directory"
+    exit 1
+}
+
+(autoconf --version) < /dev/null > /dev/null 2>&1 || {
+  echo
+  echo "**Error**: You must have \`autoconf' installed."
+  echo "Download the appropriate package for your distribution,"
+  echo "or get the source tarball at ftp://ftp.gnu.org/pub/gnu/"
+  DIE=1
+}
+
+(grep "^LT_INIT" $srcdir/configure.ac >/dev/null) && {
+  (libtoolize --version) < /dev/null > /dev/null 2>&1 \
+	  && LIBTOOLIZE=libtoolize || {
+	(glibtoolize --version) < /dev/null > /dev/null 2>&1 \
+		&& LIBTOOLIZE=glibtoolize || {
+      echo
+      echo "**Error**: You must have \`libtool' installed."
+      echo "You can get it from: ftp://ftp.gnu.org/pub/gnu/"
+      DIE=1
+    }
+  }
+}
+
+(automake --version) < /dev/null > /dev/null 2>&1 || {
+  echo
+  echo "**Error**: You must have \`automake' installed."
+  echo "You can get it from: ftp://ftp.gnu.org/pub/gnu/"
+  DIE=1
+  NO_AUTOMAKE=yes
+}
+
+
+# if no automake, don't bother testing for aclocal
+test -n "$NO_AUTOMAKE" || (aclocal --version) < /dev/null > /dev/null 2>&1 || {
+  echo
+  echo "**Error**: Missing \`aclocal'.  The version of \`automake'"
+  echo "installed doesn't appear recent enough."
+  echo "You can get automake from ftp://ftp.gnu.org/pub/gnu/"
+  DIE=1
+}
+
+if test "$DIE" -eq 1; then
+  exit 1
+fi
+
+if test -z "$*"; then
+  echo "**Warning**: I am going to run \`configure' with no arguments."
+  echo "If you wish to pass any to it, please specify them on the"
+  echo \`$0\'" command line."
+  echo
+fi
+
+# Make some directories required by automake, if they don't exist
+if ! [ -d config ]; then mkdir -v config; fi
+if ! [ -d m4     ]; then mkdir -v m4;     fi
+
+case $CC in
+xlc )
+  am_opt=--include-deps;;
+esac
+
+echo "Running aclocal $aclocalinclude ..."
+aclocal $ACLOCAL_FLAGS || exit 1
+echo "Running $LIBTOOLIZE ..."
+$LIBTOOLIZE || exit 1
+echo "Running automake --gnu $am_opt ..."
+automake --add-missing --gnu $am_opt || exit 1
+echo "Running autoconf ..."
+autoconf || exit 1
+
+if ( echo "$@" | grep -q -e "--no-configure" ); then
+  NOCONFIGURE=1
+fi
+
+conf_flags="--enable-maintainer-mode --enable-debug --disable-silent-rules"
+
+if test x$NOCONFIGURE = x; then
+  echo Running $srcdir/configure $conf_flags "$@" ...
+  $srcdir/configure $conf_flags "$@" \
+  && echo Now type \`make\' to compile. || exit 1
+else
+  echo Skipping configure process.
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,10 @@ AC_CONFIG_SRCDIR(RtMidi.cpp)
 AC_CONFIG_FILES([rtmidi-config librtmidi.pc Makefile tests/Makefile])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 
+# Enable some nice automake features if they are available
+m4_ifdef([AM_MAINTAINER_MODE], [AM_MAINTAINER_MODE])
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+
 # Fill GXX with something before test.
 AC_SUBST( GXX, ["no"] )
 AC_SUBST(noinst_LIBRARIES)


### PR DESCRIPTION
Some users are having trouble running the autotools programs in the correct order.  The presence of a script to do so can be useful, and is commonly called autogen.sh.  This PR adds such a script to rtmidi, and also enables a couple of nice automake features, (silent build and maintainer mode).

Should fix #56 and #45.