### PR TITLE
Fix version in rtmidi.pc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 AC_INIT(RtMidi, 2.1.1, gary@music.mcgill.ca, rtmidi)
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_SRCDIR(RtMidi.cpp)
-AC_CONFIG_FILES([rtmidi-config rtmidi.pc Makefile tests/Makefile doc/Makefile])
+AC_CONFIG_FILES([rtmidi-config rtmidi.pc Makefile tests/Makefile doc/Makefile doc/doxygen/Doxyfile])
 AM_INIT_AUTOMAKE([1.14 -Wall -Werror foreign subdir-objects])
 
 # libtool version: current:revision:age
@@ -83,7 +83,6 @@ AC_CHECK_PROG( DOXYGEN, [doxygen], [doxygen] )
 AM_CONDITIONAL( MAKE_DOC, [test "x${DOXYGEN}" != x] )
 
 # Copy doc files to build dir if necessary
-AC_CONFIG_LINKS( [doc/doxygen/Doxyfile:doc/doxygen/Doxyfile] )
 AC_CONFIG_LINKS( [doc/doxygen/footer.html:doc/doxygen/footer.html] )
 AC_CONFIG_LINKS( [doc/doxygen/header.html:doc/doxygen/header.html] )
 AC_CONFIG_LINKS( [doc/doxygen/tutorial.txt:doc/doxygen/tutorial.txt] )

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,15 @@ m4_define([lt_current_minus_age], [m4_eval(lt_current - lt_age)])
 SO_VERSION=lt_version_info
 AC_SUBST(SO_VERSION)
 
+# Check version number coherency between RtMidi.h and configure.ac
+AC_MSG_CHECKING([that version numbers are coherent])
+AC_RUN_IFELSE(
+   [AC_LANG_PROGRAM([#include <string.h>
+                     `grep "define RTMIDI_VERSION" $srcdir/RtMidi.h`],
+                    [return strcmp(RTMIDI_VERSION, PACKAGE_VERSION);])],
+   [AC_MSG_RESULT([yes])],
+   [AC_MSG_FAILURE([testing RTMIDI_VERSION==PACKAGE_VERSION failed, check that RtMidi.h defines RTMIDI_VERSION as "$PACKAGE_VERSION" or that the first line of configure.ac has been updated.])])
+
 # Enable some nice automake features if they are available
 m4_ifdef([AM_MAINTAINER_MODE], [AM_MAINTAINER_MODE])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])

--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -32,7 +32,7 @@ PROJECT_NAME           = RtMidi
 # This could be handy for archiving the generated documentation or 
 # if some version control system is used.
 
-PROJECT_NUMBER         = 2.1.0
+PROJECT_NUMBER         = @PACKAGE_VERSION
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description 
 # for a project that appears at the top of each page and should give viewer 

--- a/rtmidi.pc.in
+++ b/rtmidi.pc.in
@@ -5,7 +5,7 @@ includedir=${prefix}/include/rtmidi
 
 Name: librtmidi
 Description: RtMidi - a set of C++ classes that provide a common API for realtime MIDI input/output
-Version: 2.1.0
+Version: @PACKAGE_VERSION@
 Requires: @req@ 
 Libs: -L${libdir} -lrtmidi
 Libs.private: -lpthread


### PR DESCRIPTION
Sorry for the annoying post-release PR... i noticed that the version number in rtmidi.pc was not updated.  (It happens!)

So, this PR proposes to get this from the autoconf variable.  Also, to ensure consistency between the version number listed in configure.ac and RtMidi.h, it adds a test to configure.ac that compares them and errors out if they are different.

(The alternative would be to remove `#define RTMIDI_VERSION` from RtMidi.h, or have RtMidi.h be a generated file, but these solutions seem to me to be more annoying than just automatically checking it..)
