### PR TITLE
A couple of not very urgent patches to configure.ac and autogen.sh.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -21,6 +21,10 @@ fi
     exit 1
 }
 
+# Make some directories required by automake, if they don't exist
+if ! [ -d config ]; then mkdir -v config; fi
+if ! [ -d m4     ]; then mkdir -v m4;     fi
+
 if ! autoreconf --version </dev/null >/dev/null 2>&1
 then
 
@@ -66,10 +70,6 @@ test -n "$NO_AUTOMAKE" || (aclocal --version) < /dev/null > /dev/null 2>&1 || {
 if test "$DIE" -eq 1; then
   exit 1
 fi
-
-# Make some directories required by automake, if they don't exist
-if ! [ -d config ]; then mkdir -v config; fi
-if ! [ -d m4     ]; then mkdir -v m4;     fi
 
 case $CC in
 xlc )

--- a/configure.ac
+++ b/configure.ac
@@ -93,16 +93,6 @@ AC_CONFIG_LINKS( [doc/images/mcgill.gif:doc/images/mcgill.gif] )
 # Checks for package options and external software
 AC_CANONICAL_HOST
 
-AC_SUBST( sharedlib, ["librtmidi.so"] )
-AC_SUBST( sharedname, ["librtmidi.so.\$(RELEASE)"] )
-AC_SUBST( libflags, ["-shared -Wl,-soname,\$(SHARED).\$(MAJOR) -o \$(SHARED).\$(RELEASE)"] )
-case $host in
-  *-apple*)
-  AC_SUBST( sharedlib, ["librtmidi.dylib"] )
-  AC_SUBST( sharedname, ["librtmidi.\$(RELEASE).dylib"] )
-  AC_SUBST( libflags, ["-dynamiclib -o librtmidi.\$(RELEASE).dylib"] )
-esac
-
 AC_SUBST( api, [""] )
 AC_SUBST( req, [""] )
 AC_MSG_CHECKING(for MIDI API)


### PR DESCRIPTION
Just stops autoreconf complaining about the config directory if it's not there, and also removes some unnecessary left-over AC_SUBSTs.