### PR TITLE
Add error number when MidiInCore::initialize fails

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -570,7 +570,9 @@ void MidiInCore :: initialize( const std::string& clientName )
   CFStringRef name = CFStringCreateWithCString( NULL, clientName.c_str(), kCFStringEncodingASCII );
   OSStatus result = MIDIClientCreate(name, NULL, NULL, &client );
   if ( result != noErr ) {
-    errorString_ = "MidiInCore::initialize: error creating OS-X MIDI client object.";
+    std::ostringstream ost;
+    ost << "MidiInCore::initialize: error creating OS-X MIDI client object (" << result << ").";
+    errorString_ = ost.str();
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
   }

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -861,7 +861,9 @@ void MidiOutCore :: initialize( const std::string& clientName )
   CFStringRef name = CFStringCreateWithCString( NULL, clientName.c_str(), kCFStringEncodingASCII );
   OSStatus result = MIDIClientCreate(name, NULL, NULL, &client );
   if ( result != noErr ) {
-    errorString_ = "MidiOutCore::initialize: error creating OS-X MIDI client object.";
+    std::ostringstream ost;
+    ost << "MidiInCore::initialize: error creating OS-X MIDI client object (" << result << ").";
+    errorString_ = ost.str();
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
   }


### PR DESCRIPTION
In order to debug connection issue, I added the error code return by *MIDIClientCreate*. If needed I can add this behavior to other midi error case.