### PR TITLE
using samples to provide code examples in doxygen

### DIFF
--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -729,7 +729,7 @@ EXCLUDE_SYMBOLS        =
 # directories that contain example code fragments that are included (see 
 # the \include command).
 
-EXAMPLE_PATH           = 
+EXAMPLE_PATH           = samples
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the 
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp 

--- a/doc/doxygen/samples/getting_started.cpp
+++ b/doc/doxygen/samples/getting_started.cpp
@@ -1,0 +1,11 @@
+#include "RtMidi.h"
+
+int main() {
+  try {
+    RtMidiIn midiin;
+  } catch (RtMidiError &error) {
+    // Handle the exception here
+    error.printMessage();
+  }
+  return 0;
+}

--- a/doc/doxygen/tutorial.txt
+++ b/doc/doxygen/tutorial.txt
@@ -27,27 +27,7 @@ Latest Release (11 February 2016): <A href="http://www.music.mcgill.ca/~gary/rtm
 
 The first thing that must be done when using RtMidi is to create an instance of the RtMidiIn or RtMidiOut subclasses.  RtMidi is an abstract base class, which itself cannot be instantiated.  Each default constructor attempts to establish any necessary "connections" with the underlying MIDI system.  RtMidi uses C++ exceptions to report errors, necessitating try/catch blocks around many member functions.  An RtMidiError can be thrown during instantiation in some circumstances.  A warning message may also be reported if no MIDI devices are found during instantiation.  The RtMidi classes have been designed to work with "hot pluggable" or virtual (software) MIDI devices, making it possible to connect to MIDI devices that may not have been present when the classes were instantiated.  The following code example demonstrates default object construction and destruction:
 
-\code
-
-#include "RtMidi.h"
-
-int main()
-{
-  RtMidiIn *midiin = 0;
-
-  // RtMidiIn constructor
-  try {
-    midiin = new RtMidiIn();
-  }
-  catch (RtMidiError &error) {
-    // Handle the exception here
-    error.printMessage();
-  }
-
-  // Clean up
-  delete midiin;
-}
-\endcode
+\include getting_started.cpp
 
 Obviously, this example doesn't demonstrate any of the real functionality of RtMidi.  However, all uses of RtMidi must begin with construction and must end with class destruction.  Further, it is necessary that all class methods that can throw a C++ exception be called within a try/catch block.
 


### PR DESCRIPTION
sample snippets are added to doc/doxygen/samples and
included with \include into doxygen.

this also means, that it is possible to compile the
examples and check, if they are (still) compiling.