### PR TITLE
Initialize firstErrorOccurred_

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -231,7 +231,7 @@ RtMidiOut :: ~RtMidiOut() throw()
 //*********************************************************************//
 
 MidiApi :: MidiApi( void )
-  : apiData_( 0 ), connected_( false ), errorCallback_(0), errorCallbackUserData_(0)
+  : apiData_( 0 ), connected_( false ), errorCallback_(0), firstErrorOccurred_(false), errorCallbackUserData_(0)
 {
 }
 


### PR DESCRIPTION
The initializer was lost when changing firstErrorOccured from static to member (c39bb17ab47499fc9827abc100b94fb8c71715ed).

This causes error() to return prematurely and ignore all errors, if an error callback is set and fEO happens to have initialized to `true`.