### PR TITLE
changed printf to std::cout to fix compile error + make consistent wi…

### DIFF
--- a/tests/midiclock.cpp
+++ b/tests/midiclock.cpp
@@ -46,7 +46,7 @@ void mycallback( double deltatime, std::vector< unsigned char > *message, void *
   if (msg == 0xF8) {
     if (++*clock_count == 24) {
       double bpm = 60.0 / 24.0 / deltatime;
-      printf("One beat, estimated BPM = %f\n", bpm);
+      std::cout << "One beat, estimated BPM = " << bpm <<std::endl;
       *clock_count = 0;
     }
   }


### PR DESCRIPTION
just checked out a clean copy of rtmidi and it fails to compile on test/midiclock.cpp in linux (both Raspbian and Ubuntu) due to to printf not being defined. it passes on OSX since its probably implicitly defined by the compiler.

since the rest of the program uses std::cout anyway, it probably makes sense to do so here as well?