### PR TITLE
Avoid "unreferenced formal parameter" warning in dummy API.

### DIFF
--- a/RtMidi.h
+++ b/RtMidi.h
@@ -736,7 +736,7 @@ class MidiInDummy: public MidiInApi
   void openVirtualPort( const std::string /*portName*/ ) {}
   void closePort( void ) {}
   unsigned int getPortCount( void ) { return 0; }
-  std::string getPortName( unsigned int portNumber ) { return ""; }
+  std::string getPortName( unsigned int /*portNumber*/ ) { return ""; }
 
  protected:
   void initialize( const std::string& /*clientName*/ ) {}


### PR DESCRIPTION
In other API functions, the parameter name is already commented out to avoid the aforementioned warning. For `getPortName`, the parameter name is not commented out yet.