### PR TITLE
[rtmidi_c] Add struct and stddef to get compiling under gcc happy

### DIFF
--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -1,5 +1,6 @@
 
 #include <stdbool.h>
+#include <stddef.h>
 #ifndef RTMIDI_C_H
 #define RTMIDI_C_H
 
@@ -20,9 +21,9 @@ struct RtMidiWrapper {
     const char* msg;
 };
 
-typedef RtMidiWrapper* RtMidiPtr;
-typedef RtMidiWrapper* RtMidiInPtr;
-typedef RtMidiWrapper* RtMidiOutPtr;
+typedef struct RtMidiWrapper* RtMidiPtr;
+typedef struct RtMidiWrapper* RtMidiInPtr;
+typedef struct RtMidiWrapper* RtMidiOutPtr;
 
   enum RtMidiApi {
     RT_MIDI_API_UNSPECIFIED,    /*!< Search for a working compiled API. */


### PR DESCRIPTION
This adds a few things that `gcc` complained about when compiling against `rtmidi_c.h`.