### PR TITLE
Make sendMessage param const

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1013,7 +1013,7 @@ void MidiOutCore :: openVirtualPort( std::string portName )
   data->endpoint = endpoint;
 }
 
-void MidiOutCore :: sendMessage( std::vector<unsigned char> *message )
+void MidiOutCore :: sendMessage( const std::vector<unsigned char> *message )
 {
   // We use the MIDISendSysex() function to asynchronously send sysex
   // messages.  Otherwise, we use a single CoreMidi MIDIPacket.
@@ -1852,7 +1852,7 @@ void MidiOutAlsa :: openVirtualPort( std::string portName )
   }
 }
 
-void MidiOutAlsa :: sendMessage( std::vector<unsigned char> *message )
+void MidiOutAlsa :: sendMessage( const std::vector<unsigned char> *message )
 {
   int result;
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
@@ -2349,7 +2349,7 @@ void MidiOutWinMM :: openVirtualPort( std::string /*portName*/ )
   error( RtMidiError::WARNING, errorString_ );
 }
 
-void MidiOutWinMM :: sendMessage( std::vector<unsigned char> *message )
+void MidiOutWinMM :: sendMessage( const std::vector<unsigned char> *message )
 {
   if ( !connected_ ) return;
 
@@ -2833,7 +2833,7 @@ void MidiOutJack :: closePort()
   data->port = NULL;
 }
 
-void MidiOutJack :: sendMessage( std::vector<unsigned char> *message )
+void MidiOutJack :: sendMessage( const std::vector<unsigned char> *message )
 {
   int nBytes = message->size();
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -406,7 +406,7 @@ class RtMidiOut : public RtMidi
       An exception is thrown if an error occurs during output or an
       output connection was not previously established.
   */
-  void sendMessage( std::vector<unsigned char> *message );
+  void sendMessage( const std::vector<unsigned char> *message );
 
   //! Set an error callback function to be invoked when an error has occured.
   /*!
@@ -529,7 +529,7 @@ class MidiOutApi : public MidiApi
 
   MidiOutApi( void );
   virtual ~MidiOutApi( void );
-  virtual void sendMessage( std::vector<unsigned char> *message ) = 0;
+  virtual void sendMessage( const std::vector<unsigned char> *message ) = 0;
 };
 
 // **************************************************************** //
@@ -558,7 +558,7 @@ inline void RtMidiOut :: closePort( void ) { rtapi_->closePort(); }
 inline bool RtMidiOut :: isPortOpen() const { return rtapi_->isPortOpen(); }
 inline unsigned int RtMidiOut :: getPortCount( void ) { return rtapi_->getPortCount(); }
 inline std::string RtMidiOut :: getPortName( unsigned int portNumber ) { return rtapi_->getPortName( portNumber ); }
-inline void RtMidiOut :: sendMessage( std::vector<unsigned char> *message ) { ((MidiOutApi *)rtapi_)->sendMessage( message ); }
+inline void RtMidiOut :: sendMessage( const std::vector<unsigned char> *message ) { ((MidiOutApi *)rtapi_)->sendMessage( message ); }
 inline void RtMidiOut :: setErrorCallback( RtMidiErrorCallback errorCallback, void *userData ) { rtapi_->setErrorCallback(errorCallback, userData); }
 
 // **************************************************************** //
@@ -600,7 +600,7 @@ class MidiOutCore: public MidiOutApi
   void closePort( void );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
-  void sendMessage( std::vector<unsigned char> *message );
+  void sendMessage( const std::vector<unsigned char> *message );
 
  protected:
   void initialize( const std::string& clientName );
@@ -640,7 +640,7 @@ class MidiOutJack: public MidiOutApi
   void closePort( void );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
-  void sendMessage( std::vector<unsigned char> *message );
+  void sendMessage( const std::vector<unsigned char> *message );
 
  protected:
   std::string clientName;
@@ -680,7 +680,7 @@ class MidiOutAlsa: public MidiOutApi
   void closePort( void );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
-  void sendMessage( std::vector<unsigned char> *message );
+  void sendMessage( const std::vector<unsigned char> *message );
 
  protected:
   void initialize( const std::string& clientName );
@@ -717,7 +717,7 @@ class MidiOutWinMM: public MidiOutApi
   void closePort( void );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
-  void sendMessage( std::vector<unsigned char> *message );
+  void sendMessage( const std::vector<unsigned char> *message );
 
  protected:
   void initialize( const std::string& clientName );
@@ -752,7 +752,7 @@ class MidiOutDummy: public MidiOutApi
   void closePort( void ) {}
   unsigned int getPortCount( void ) { return 0; }
   std::string getPortName( unsigned int /*portNumber*/ ) { return ""; }
-  void sendMessage( std::vector<unsigned char> * /*message*/ ) {}
+  void sendMessage( const std::vector<unsigned char> * /*message*/ ) {}
 
  protected:
   void initialize( const std::string& /*clientName*/ ) {}

--- a/rtmidi_c.cpp
+++ b/rtmidi_c.cpp
@@ -222,16 +222,15 @@ double rtmidi_in_get_message (RtMidiInPtr device,
 {
     try {
         // FIXME: use allocator to achieve efficient buffering
-        std::vector<unsigned char> *v = new std::vector<unsigned char> ();
-        double ret = ((RtMidiIn*) device->ptr)->getMessage (v);
-        *size = v->size ();
+        std::vector<unsigned char> v;
+        double ret = ((RtMidiIn*) device->ptr)->getMessage (&v);
+        *size = v.size ();
 
-        if (v->size () > 0) {
+        if (v.size () > 0) {
             *message = (unsigned char *) 
-                        malloc (sizeof (unsigned char *) * (int) v->size ());
-            memcpy (*message, v->data (), (int) v->size ());
+                        malloc (sizeof (unsigned char *) * (int) v.size ());
+            memcpy (*message, v.data (), (int) v.size ());
         }
-        delete v;
         return ret;
     } 
     catch (const RtMidiError & err) {
@@ -312,10 +311,8 @@ int rtmidi_out_send_message (RtMidiOutPtr device, const unsigned char *message, 
 {
     try {
         // FIXME: use allocator to achieve efficient buffering
-        std::vector<unsigned char> *v = new std::vector<unsigned char> (length);
-        memcpy (v->data (), message, length);
-        ((RtMidiOut*) device->ptr)->sendMessage (v);
-        delete v;
+        std::vector<unsigned char> v (message, message + length);
+        ((RtMidiOut*) device->ptr)->sendMessage (&v);
         return 0;
     }
     catch (const RtMidiError & err) {


### PR DESCRIPTION
There is no reason forr the sendMessage parameter to not be const. Making it const gives confidence to the user that they can e.g. reuse a message and do not have to re-allocate it.

This pull request also contains another little change in the C wrapper, which avoids the allocation of the data vector on the heap while it can just as well be placed on the stack.