### PR TITLE
No allocations on sendMessage

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -2075,7 +2075,7 @@ static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
   }
   else {
     // As long as we haven't reached our queue size limit, push the message.
-    if (!data->queue.push(message))
+    if (!data->queue.push(apiData->message))
       std::cerr << "\nMidiInWinMM: message queue limit reached!!\n\n";
   }
 
@@ -2168,7 +2168,7 @@ void MidiInWinMM :: openPort( unsigned int portNumber, const std::string /*portN
     result = midiInPrepareHeader( data->inHandle, data->sysexBuffer[i], sizeof(MIDIHDR) );
     if ( result != MMSYSERR_NOERROR ) {
       midiInClose( data->inHandle );
-      data->inHandle = INVALID_HANDLE_VALUE;
+      data->inHandle = 0;
       errorString_ = "MidiInWinMM::openPort: error starting Windows MM MIDI input port (PrepareHeader).";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
@@ -2178,7 +2178,7 @@ void MidiInWinMM :: openPort( unsigned int portNumber, const std::string /*portN
     result = midiInAddBuffer( data->inHandle, data->sysexBuffer[i], sizeof(MIDIHDR) );
     if ( result != MMSYSERR_NOERROR ) {
       midiInClose( data->inHandle );
-      data->inHandle = INVALID_HANDLE_VALUE;
+      data->inHandle = 0;
       errorString_ = "MidiInWinMM::openPort: error starting Windows MM MIDI input port (AddBuffer).";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
@@ -2188,7 +2188,7 @@ void MidiInWinMM :: openPort( unsigned int portNumber, const std::string /*portN
   result = midiInStart( data->inHandle );
   if ( result != MMSYSERR_NOERROR ) {
     midiInClose( data->inHandle );
-    data->inHandle = INVALID_HANDLE_VALUE;
+    data->inHandle = 0;
     errorString_ = "MidiInWinMM::openPort: error starting Windows MM MIDI input port.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
@@ -2218,7 +2218,7 @@ void MidiInWinMM :: closePort( void )
       delete [] data->sysexBuffer[i];
       if ( result != MMSYSERR_NOERROR ) {
         midiInClose( data->inHandle );
-        data->inHandle = INVALID_HANDLE_VALUE;
+        data->inHandle = 0;
         errorString_ = "MidiInWinMM::openPort: error closing Windows MM MIDI input port (midiInUnprepareHeader).";
         error( RtMidiError::DRIVER_ERROR, errorString_ );
         return;
@@ -2226,7 +2226,7 @@ void MidiInWinMM :: closePort( void )
     }
 
     midiInClose( data->inHandle );
-    data->inHandle = INVALID_HANDLE_VALUE;
+    data->inHandle = 0;
     connected_ = false;
     LeaveCriticalSection( &(data->_mutex) );
   }
@@ -2393,7 +2393,7 @@ void MidiOutWinMM :: closePort( void )
     WinMidiData *data = static_cast<WinMidiData *> (apiData_);
     midiOutReset( data->outHandle );
     midiOutClose( data->outHandle );
-    data->outHandle = INVALID_HANDLE_VALUE;
+    data->outHandle = 0;
     connected_ = false;
   }
 }

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -695,7 +695,7 @@ class MidiOutAlsa: public MidiOutApi
   void closePort( void );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
-  void sendMessage( const std::vector<unsigned char> *message );
+  void sendMessage( const unsigned char *message, size_t size );
 
  protected:
   void initialize( const std::string& clientName );


### PR DESCRIPTION
Add a second sendMessage prototype that takes a normal C array instead of std::vector.
From discussion in #118.
