### PR TITLE
Ensure that port names are always UTF-8 on Windows, even when not compiling as UNICODE.

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -2279,7 +2279,7 @@ std::string MidiInWinMM :: getPortName( unsigned int portNumber )
 
   MIDIINCAPS deviceCaps;
   midiInGetDevCaps( portNumber, &deviceCaps, sizeof(MIDIINCAPS));
-  stringName = ConvertToUTF8(deviceCaps.szPname);
+  stringName = ConvertToUTF8( deviceCaps.szPname );
 
   // Next lines added to add the portNumber to the name so that 
   // the device's names are sure to be listed with individual names
@@ -2348,7 +2348,7 @@ std::string MidiOutWinMM :: getPortName( unsigned int portNumber )
 
   MIDIOUTCAPS deviceCaps;
   midiOutGetDevCaps( portNumber, &deviceCaps, sizeof(MIDIOUTCAPS));
-  stringName = ConvertToUTF8(deviceCaps.szPname);
+  stringName = ConvertToUTF8( deviceCaps.szPname );
 
   // Next lines added to add the portNumber to the name so that 
   // the device's names are sure to be listed with individual names

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1974,29 +1974,29 @@ void MidiOutAlsa :: sendMessage( const unsigned char *message, size_t size )
 // Convert a null-terminated wide string or ANSI-encoded string to UTF-8.
 static std::string ConvertToUTF8(const TCHAR *str)
 {
-	std::string u8str;
-	const WCHAR *wstr = L"";
+  std::string u8str;
+  const WCHAR *wstr = L"";
 #if defined( UNICODE ) || defined( _UNICODE )
-	wstr = str;
+  wstr = str;
 #else
-	// Convert from ANSI encoding to wide string
-	int wlength = MultiByteToWideChar( CP_ACP, 0, str, -1, NULL, 0 );
-	std::wstring wstrtemp;
-	if(wlength)
-	{
-		wstrtemp.assign(wlength - 1, 0);
-		MultiByteToWideChar(CP_ACP, 0, str, -1, &wstrtemp[0], wlength);
-		wstr = &wstrtemp[0];
-	}
+  // Convert from ANSI encoding to wide string
+  int wlength = MultiByteToWideChar( CP_ACP, 0, str, -1, NULL, 0 );
+  std::wstring wstrtemp;
+  if ( wlength )
+  {
+    wstrtemp.assign( wlength - 1, 0 );
+    MultiByteToWideChar( CP_ACP, 0, str, -1, &wstrtemp[0], wlength );
+    wstr = &wstrtemp[0];
+  }
 #endif
-	// Convert from wide string to UTF-8
-	int length = WideCharToMultiByte( CP_UTF8, 0, wstr, -1, NULL, 0, NULL, NULL );
-	if(length)
-	{
-		u8str.assign(length - 1, 0);
-		length = WideCharToMultiByte( CP_UTF8, 0, wstr, -1, &u8str[0], length, NULL, NULL );
-	}
-	return u8str;
+  // Convert from wide string to UTF-8
+  int length = WideCharToMultiByte( CP_UTF8, 0, wstr, -1, NULL, 0, NULL, NULL );
+  if ( length )
+  {
+    u8str.assign( length - 1, 0 );
+    length = WideCharToMultiByte( CP_UTF8, 0, wstr, -1, &u8str[0], length, NULL, NULL );
+  }
+  return u8str;
 }
 
 #define  RT_SYSEX_BUFFER_SIZE 1024

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1971,6 +1971,34 @@ void MidiOutAlsa :: sendMessage( const unsigned char *message, size_t size )
 #include <windows.h>
 #include <mmsystem.h>
 
+// Convert a null-terminated wide string or ANSI-encoded string to UTF-8.
+static std::string ConvertToUTF8(const TCHAR *str)
+{
+	std::string u8str;
+	const WCHAR *wstr = L"";
+#if defined( UNICODE ) || defined( _UNICODE )
+	wstr = str;
+#else
+	// Convert from ANSI encoding to wide string
+	int wlength = MultiByteToWideChar( CP_ACP, 0, str, -1, NULL, 0 );
+	std::wstring wstrtemp;
+	if(wlength)
+	{
+		wstrtemp.assign(wlength - 1, 0);
+		MultiByteToWideChar(CP_ACP, 0, str, -1, &wstrtemp[0], wlength);
+		wstr = &wstrtemp[0];
+	}
+#endif
+	// Convert from wide string to UTF-8
+	int length = WideCharToMultiByte( CP_UTF8, 0, wstr, -1, NULL, 0, NULL, NULL );
+	if(length)
+	{
+		u8str.assign(length - 1, 0);
+		length = WideCharToMultiByte( CP_UTF8, 0, wstr, -1, &u8str[0], length, NULL, NULL );
+	}
+	return u8str;
+}
+
 #define  RT_SYSEX_BUFFER_SIZE 1024
 #define  RT_SYSEX_BUFFER_COUNT 4
 
@@ -2251,14 +2279,7 @@ std::string MidiInWinMM :: getPortName( unsigned int portNumber )
 
   MIDIINCAPS deviceCaps;
   midiInGetDevCaps( portNumber, &deviceCaps, sizeof(MIDIINCAPS));
-
-#if defined( UNICODE ) || defined( _UNICODE )
-  int length = WideCharToMultiByte(CP_UTF8, 0, deviceCaps.szPname, -1, NULL, 0, NULL, NULL) - 1;
-  stringName.assign( length, 0 );
-  length = WideCharToMultiByte(CP_UTF8, 0, deviceCaps.szPname, static_cast<int>(wcslen(deviceCaps.szPname)), &stringName[0], length, NULL, NULL);
-#else
-  stringName = std::string( deviceCaps.szPname );
-#endif
+  stringName = ConvertToUTF8(deviceCaps.szPname);
 
   // Next lines added to add the portNumber to the name so that 
   // the device's names are sure to be listed with individual names
@@ -2327,14 +2348,7 @@ std::string MidiOutWinMM :: getPortName( unsigned int portNumber )
 
   MIDIOUTCAPS deviceCaps;
   midiOutGetDevCaps( portNumber, &deviceCaps, sizeof(MIDIOUTCAPS));
-
-#if defined( UNICODE ) || defined( _UNICODE )
-  int length = WideCharToMultiByte(CP_UTF8, 0, deviceCaps.szPname, -1, NULL, 0, NULL, NULL) - 1;
-  stringName.assign( length, 0 );
-  length = WideCharToMultiByte(CP_UTF8, 0, deviceCaps.szPname, static_cast<int>(wcslen(deviceCaps.szPname)), &stringName[0], length, NULL, NULL);
-#else
-  stringName = std::string( deviceCaps.szPname );
-#endif
+  stringName = ConvertToUTF8(deviceCaps.szPname);
 
   // Next lines added to add the portNumber to the name so that 
   // the device's names are sure to be listed with individual names

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -43,12 +43,111 @@
 #ifndef RTMIDI_H
 #define RTMIDI_H
 
-#define RTMIDI_VERSION "2.1.1"
+#define RTMIDI_VERSION "2.2.0"
 
 #include <exception>
 #include <iostream>
 #include <string>
 #include <vector>
+
+/************************************************************************/
+/*! \class RtMidiSpan
+    \brief Simplified version of gsl::span to hold MIDI messages.
+
+    Non-owning read-only or read-write view into a contiguous block of T
+    objects, i.e. equivalent to a (beg,end) or (data,size) tuple.
+*/
+/************************************************************************/
+
+template <typename T>
+class RtMidiSpan
+{
+ public:
+  typedef std::size_t size_type;
+
+  typedef T value_type;
+  typedef T & reference;
+  typedef T * pointer;
+  typedef const T * const_pointer;
+  typedef const T & const_reference;
+
+  typedef pointer iterator;
+  typedef const_pointer const_iterator;
+
+  typedef typename std::iterator_traits<iterator>::difference_type difference_type;
+
+ public:
+  //! Construct an empty memory view.
+  RtMidiSpan() : begin_(NULL), end_(NULL) { }
+  //! Construct a memory view referencing the data in [beg, end[.
+  RtMidiSpan( pointer beg, pointer end ) : begin_(beg), end_(end) { }
+  //! Construct a memory view referencing the data in [data, data + size[.
+  RtMidiSpan( pointer data, size_type size ) : begin_(data), end_(data + size) { }
+  //! Construct a memory view from a C array.
+  template <typename U, std::size_t N> RtMidiSpan( U(&arr)[N] ) : begin_(arr), end_(arr + N) { }
+  //! Construct a memory view from a C++ container backed by contiguous memory. The container is required to provide empty(), size() and operator[].
+  template <typename Cont> RtMidiSpan( Cont &cont ) : begin_(cont.empty() ? NULL : &(cont[0])), end_(cont.empty() ? NULL : &(cont[0]) + cont.size()) { }
+  //! Construct a memory view from an existing RtMidiSpan.
+  RtMidiSpan( const RtMidiSpan &other ) : begin_(other.begin()), end_(other.end()) { }
+  //! Construct a memory view from an existing RtMidiSpan of different type, if the types are compatible.
+  template <typename U> RtMidiSpan( const RtMidiSpan<U> &other ) : begin_(other.begin()), end_(other.end()) { }
+
+  //! Assignment from an existing RtMidiSpan.
+  RtMidiSpan & operator = ( RtMidiSpan other ) { begin_ = other.begin(); end_ = other.end(); return *this; }
+
+  //! Returns an iterator pointing to the beginning of the memory view.
+  iterator begin() const { return iterator(begin_); }
+  //! Returns an iterator pointing to the end of the memory view.
+  iterator end() const { return iterator(end_); }
+
+  //! Returns a constant iterator pointing to the beginning of the memory view.
+  const_iterator cbegin() const { return const_iterator(begin()); }
+  //! Returns a constant iterator pointing to the end of the memory view.
+  const_iterator cend() const { return const_iterator(end()); }
+
+  //! Conversion to bool; Returns true if the memory view is not empty.
+  operator bool() const throw() { return begin_ != NULL; }
+
+  //! Access an element inside the memory view.
+  reference operator[]( size_type index ) { return at(index); }
+  //! Access an element inside the memory view.
+  const_reference operator[]( size_type index ) const { return at(index); }
+
+  bool operator==( RtMidiSpan const & other ) const throw() { return size() == other.size() && (begin_ == other.m_beg || std::equal(begin(), end(), other.begin())); }
+  bool operator!=( RtMidiSpan const & other ) const throw() { return !(*this == other); }
+
+  //! Access an element inside the memory view.
+  reference at( size_type index ) { return begin_[index]; }
+  //! Access an element inside the memory view.
+  const_reference at( size_type index ) const { return begin_[index]; }
+
+  //! Returns a pointer to the start of the memory view.
+  pointer data() const throw() { return begin_; }
+
+  //! Returns true if the memory view does not contain any elements.
+  bool empty() const throw() { return size() == 0; }
+
+  //! Returns the size of the memory view.
+  size_type size() const throw() { return std::distance(begin_, end_); }
+  //! Returns the size of the memory view.
+  size_type length() const throw() { return size(); }
+
+ protected:
+  T *begin_;
+  T *end_;
+};
+
+
+/************************************************************************/
+/*! \class RtMidiMessage
+    \brief Class used for sending MIDI messages to RtMidi.
+
+    See the documentation on RtMidiSpan.
+*/
+/************************************************************************/
+
+typedef RtMidiSpan<const unsigned char> RtMidiMessage;
+
 
 /************************************************************************/
 /*! \class RtMidiError
@@ -408,6 +507,13 @@ class RtMidiOut : public RtMidi
   */
   void sendMessage( const std::vector<unsigned char> *message );
 
+  //! Immediately send a single message out an open MIDI output port.
+  /*!
+  An exception is thrown if an error occurs during output or an
+  output connection was not previously established.
+  */
+  void sendMessage(const RtMidiMessage &message);
+
   //! Set an error callback function to be invoked when an error has occured.
   /*!
     The callback function will be called whenever an error has occured. It is best
@@ -529,7 +635,7 @@ class MidiOutApi : public MidiApi
 
   MidiOutApi( void );
   virtual ~MidiOutApi( void );
-  virtual void sendMessage( const std::vector<unsigned char> *message ) = 0;
+  virtual void sendMessage(const RtMidiMessage &message) = 0;
 };
 
 // **************************************************************** //
@@ -558,7 +664,8 @@ inline void RtMidiOut :: closePort( void ) { rtapi_->closePort(); }
 inline bool RtMidiOut :: isPortOpen() const { return rtapi_->isPortOpen(); }
 inline unsigned int RtMidiOut :: getPortCount( void ) { return rtapi_->getPortCount(); }
 inline std::string RtMidiOut :: getPortName( unsigned int portNumber ) { return rtapi_->getPortName( portNumber ); }
-inline void RtMidiOut :: sendMessage( const std::vector<unsigned char> *message ) { ((MidiOutApi *)rtapi_)->sendMessage( message ); }
+inline void RtMidiOut :: sendMessage( const std::vector<unsigned char> *message ) { ((MidiOutApi *)rtapi_)->sendMessage( RtMidiMessage( *message ) ); }
+inline void RtMidiOut :: sendMessage( const RtMidiMessage &message ) { ((MidiOutApi *)rtapi_)->sendMessage( message ); }
 inline void RtMidiOut :: setErrorCallback( RtMidiErrorCallback errorCallback, void *userData ) { rtapi_->setErrorCallback(errorCallback, userData); }
 
 // **************************************************************** //
@@ -600,7 +707,7 @@ class MidiOutCore: public MidiOutApi
   void closePort( void );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
-  void sendMessage( const std::vector<unsigned char> *message );
+  void sendMessage( const RtMidiMessage &message );
 
  protected:
   void initialize( const std::string& clientName );
@@ -640,7 +747,7 @@ class MidiOutJack: public MidiOutApi
   void closePort( void );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
-  void sendMessage( const std::vector<unsigned char> *message );
+  void sendMessage( const RtMidiMessage &message );
 
  protected:
   std::string clientName;
@@ -680,7 +787,7 @@ class MidiOutAlsa: public MidiOutApi
   void closePort( void );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
-  void sendMessage( const std::vector<unsigned char> *message );
+  void sendMessage( const RtMidiMessage &message );
 
  protected:
   void initialize( const std::string& clientName );
@@ -717,7 +824,7 @@ class MidiOutWinMM: public MidiOutApi
   void closePort( void );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
-  void sendMessage( const std::vector<unsigned char> *message );
+  void sendMessage( const RtMidiMessage &message );
 
  protected:
   void initialize( const std::string& clientName );
@@ -752,7 +859,7 @@ class MidiOutDummy: public MidiOutApi
   void closePort( void ) {}
   unsigned int getPortCount( void ) { return 0; }
   std::string getPortName( unsigned int /*portNumber*/ ) { return ""; }
-  void sendMessage( const std::vector<unsigned char> * /*message*/ ) {}
+  void sendMessage( const RtMidiMessage & /*message*/ ) {}
 
  protected:
   void initialize( const std::string& /*clientName*/ ) {}


### PR DESCRIPTION
As discussed at https://github.com/thestk/rtmidi/commit/6f710049e58507d3f4201c13af8962388a25fdfd
