### PR TITLE
 Build breaks when compiling with --prefix and upgrading version.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -77,7 +77,6 @@ AC_ARG_ENABLE(debug,
 # Set paths if prefix is defined
 if test "x$prefix" != "x" && test "x$prefix" != "xNONE"; then
   LIBS="$LIBS -L$prefix/lib"
-  CPPFLAGS="$CPPFLAGS -I$prefix/include/rtmidi"
 fi
 
 # For -I and -D flags


### PR DESCRIPTION
Removed line which adds, when configured with prefix, include to the currently installed version (assuming prefix is always the same).
This include causes submodules (i.e. tests) to link against the currently installed library, instead of the newly compiled one, breaking build when upgrading version.