### PR TITLE
C API improvements/fixes

### DIFF
--- a/rtmidi_c.cpp
+++ b/rtmidi_c.cpp
@@ -14,12 +14,6 @@ class CallbackProxyUserData
 	void *user_data;
 };
 
-/* misc */
-int rtmidi_sizeof_rtmidi_api ()
-{
-	return sizeof (RtMidiApi);
-}
-
 /* RtMidi API */
 int rtmidi_get_compiled_api (enum RtMidiApi **apis) // return length for NULL argument.
 {

--- a/rtmidi_c.cpp
+++ b/rtmidi_c.cpp
@@ -179,7 +179,7 @@ static
 void callback_proxy (double timeStamp, std::vector<unsigned char> *message, void *userData)
 {
 	CallbackProxyUserData* data = reinterpret_cast<CallbackProxyUserData*> (userData);
-	data->c_callback (timeStamp, message->data (), data->user_data);
+	data->c_callback (timeStamp, message->data (), message->size (), data->user_data);
 }
 
 void rtmidi_in_set_callback (RtMidiInPtr device, RtMidiCCallback callback, void *userData)

--- a/rtmidi_c.cpp
+++ b/rtmidi_c.cpp
@@ -213,8 +213,8 @@ void rtmidi_in_ignore_types (RtMidiInPtr device, bool midiSysex, bool midiTime, 
 }
 
 double rtmidi_in_get_message (RtMidiInPtr device, 
-                              unsigned char **message, 
-                              size_t * size)
+                              unsigned char *message,
+                              size_t *size)
 {
     try {
         // FIXME: use allocator to achieve efficient buffering
@@ -222,7 +222,7 @@ double rtmidi_in_get_message (RtMidiInPtr device,
         double ret = ((RtMidiIn*) device->ptr)->getMessage (&v);
 
         if (v.size () > 0 && v.size() <= *size) {
-            memcpy (*message, v.data (), (int) v.size ());
+            memcpy (message, v.data (), (int) v.size ());
         }
 
         *size = v.size();

--- a/rtmidi_c.cpp
+++ b/rtmidi_c.cpp
@@ -15,9 +15,9 @@ class CallbackProxyUserData
 };
 
 /* RtMidi API */
-int rtmidi_get_compiled_api (enum RtMidiApi **apis) // return length for NULL argument.
+int rtmidi_get_compiled_api (enum RtMidiApi *apis) // return length for NULL argument.
 {
-	if (!apis || !(*apis)) {
+	if (!apis) {
 		std::vector<RtMidi::Api> *v = new std::vector<RtMidi::Api> ();
 		try {
 			RtMidi::getCompiledApi (*v);
@@ -32,7 +32,7 @@ int rtmidi_get_compiled_api (enum RtMidiApi **apis) // return length for NULL ar
 			std::vector<RtMidi::Api> *v = new std::vector<RtMidi::Api> ();
 			RtMidi::getCompiledApi (*v);
 			for (unsigned int i = 0; i < v->size (); i++)
-				(*apis) [i] = (RtMidiApi) v->at (i);
+				apis[i] = (RtMidiApi) v->at (i);
 			delete v;
 			return 0;
 		} catch (...) {

--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -59,8 +59,6 @@ enum RtMidiErrorType {
  */
 typedef void(* RtMidiCCallback) (double timeStamp, const unsigned char* message, void *userData);
 
-//! Returns the size (with sizeof) of a RtMidiApi instance.
-RTMIDIAPI int rtmidi_sizeof_rtmidi_api ();
 
 /* RtMidi API */
 

--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -57,7 +57,8 @@ enum RtMidiErrorType {
  * \param message     The midi message.
  * \param userData    Additional user data for the callback.
  */
-typedef void(* RtMidiCCallback) (double timeStamp, const unsigned char* message, void *userData);
+typedef void(* RtMidiCCallback) (double timeStamp, const unsigned char* message,
+                                 size_t messageSize, void *userData);
 
 
 /* RtMidi API */

--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -139,7 +139,7 @@ RTMIDIAPI void rtmidi_in_ignore_types (RtMidiInPtr device, bool midiSysex, bool 
  *                  be sufficient. 
  * \param size      Is used to return the size of the message obtained. 
  */
-RTMIDIAPI double rtmidi_in_get_message (RtMidiInPtr device, unsigned char **message, size_t * size);
+RTMIDIAPI double rtmidi_in_get_message (RtMidiInPtr device, unsigned char *message, size_t *size);
 
 /* RtMidiOut API */
 

--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -43,7 +43,6 @@ enum RtMidiApi {
     RT_MIDI_API_LINUX_ALSA,     /*!< The Advanced Linux Sound Architecture API. */
     RT_MIDI_API_UNIX_JACK,      /*!< The Jack Low-Latency MIDI Server API. */
     RT_MIDI_API_WINDOWS_MM,     /*!< The Microsoft Multimedia MIDI API. */
-    RT_MIDI_API_WINDOWS_KS,     /*!< The Microsoft Kernel Streaming MIDI API. */
     RT_MIDI_API_RTMIDI_DUMMY    /*!< A compilable but non-functional API. */
   };
 

--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -28,13 +28,13 @@ struct RtMidiWrapper {
 };
 
 //! Typedef for a generic RtMidi pointer.
-typedef RtMidiWrapper* RtMidiPtr;
+typedef struct RtMidiWrapper* RtMidiPtr;
 
 //! Typedef for a generic RtMidiIn pointer.
-typedef RtMidiWrapper* RtMidiInPtr;
+typedef struct RtMidiWrapper* RtMidiInPtr;
 
 //! Typedef for a generic RtMidiOut pointer.
-typedef RtMidiWrapper* RtMidiOutPtr;
+typedef struct RtMidiWrapper* RtMidiOutPtr;
 
 
 enum RtMidiApi {

--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -68,7 +68,7 @@ typedef void(* RtMidiCCallback) (double timeStamp, const unsigned char* message,
  *
  * \param apis  An array or a null value.
 */
-RTMIDIAPI int rtmidi_get_compiled_api (enum RtMidiApi **apis); // return length for NULL argument.
+RTMIDIAPI int rtmidi_get_compiled_api (enum RtMidiApi *apis); // return length for NULL argument.
 
 //! Report an error.
 RTMIDIAPI void rtmidi_error (enum RtMidiErrorType type, const char* errorString);


### PR DESCRIPTION
This covers the issues with the C API that I've found when working on Go bindings. Most of them look critical to me, so I dared to make some changes:

1. Replace `typedef RtMidiWrapper* RtMidiPtr;` with `typedef struct RtMidiWrapper* RtMidiPtr;` because the former is invalid C code and doesn't compile in C99 mode.

2. Removed RT_MIDI_API_WINDOWS_KS from the enum to make C API enum absolutely match RtAudio C++ API enum. Otherwise the numeric values will be incorrect. I haven't found any uses of RT_MIDI_API_WINDOWS_KS in the code, so I assumed it's safe to remove it from the C API, if it's not in the C++ API.

3. Removed rtmidi_sizeof_rtmidi_api. Well, this is a matter of taste, but I find `sizeof(enum RtMidiApi)` to be much more readable and explicit. Since the type is defined in the header I don't see any reasons to make a helper function for its size.

4. Removed double pointers in `rtmidi_in_get_message` and `rtmidi_get_compiled_api`. These functions do not allocate pointers, they only have been taking double pointer to double-unreference it. I find it much more clear to pass a regular pointer instead.

5. In the midi callback there was no message size. And it seems to be rather impossible to guess how may bytes from `void *message` it's safe to read without crashing. So I've changed the callback prototype to have a message size in bytes.

That being said, with these changes I find C API to be usable, and I'd be happy to add Go bindings for this library in a manner I'm doing now with RtAudio (https://github.com/thestk/rtaudio/pull/99).

Ah, and thanks for the wonderful libraries!