### PR TITLE
Debian changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# make sure that .gitignore, .travis.yml,... are not part of a
+# source-package generated via 'git archive'
+.git*      	export-ignore
+/.*		export-ignore

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,8 @@ if MAKE_DOC
 SUBDIRS += doc
 endif
 
+AM_CXXFLAGS = @visibility@
+
 lib_LTLIBRARIES = %D%/librtmidi.la
 %C%_librtmidi_la_LDFLAGS = -no-undefined -export-dynamic -version-info @SO_VERSION@
 %C%_librtmidi_la_SOURCES = \

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -124,7 +124,7 @@ void RtMidiIn :: openMidiApi( RtMidi::Api api, const std::string &clientName, un
 #endif
 }
 
-RtMidiIn :: RtMidiIn( RtMidi::Api api, const std::string &clientName, unsigned int queueSizeLimit )
+extern RTMIDI_DLL_PUBLIC RtMidiIn :: RtMidiIn( RtMidi::Api api, const std::string &clientName, unsigned int queueSizeLimit )
   : RtMidi()
 {
   if ( api != UNSPECIFIED ) {
@@ -192,7 +192,7 @@ void RtMidiOut :: openMidiApi( RtMidi::Api api, const std::string &clientName )
 #endif
 }
 
-RtMidiOut :: RtMidiOut( RtMidi::Api api, const std::string &clientName)
+extern RTMIDI_DLL_PUBLIC RtMidiOut :: RtMidiOut( RtMidi::Api api, const std::string &clientName)
 {
   if ( api != UNSPECIFIED ) {
     // Attempt to open the specified API.

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -43,6 +43,16 @@
 #ifndef RTMIDI_H
 #define RTMIDI_H
 
+#if defined _WIN32 || defined __CYGWIN__
+  #define RTMIDI_DLL_PUBLIC
+#else
+  #if __GNUC__ >= 4
+    #define RTMIDI_DLL_PUBLIC __attribute__( (visibility( "default" )) )
+  #else
+    #define RTMIDI_DLL_PUBLIC
+  #endif
+#endif
+
 #define RTMIDI_VERSION "3.0.0"
 
 #include <exception>
@@ -207,7 +217,7 @@ class RtMidi
 //
 // **************************************************************** //
 
-class RtMidiIn : public RtMidi
+class RTMIDI_DLL_PUBLIC RtMidiIn : public RtMidi
 {
  public:
 
@@ -354,7 +364,7 @@ class RtMidiIn : public RtMidi
 */
 /**********************************************************************/
 
-class RtMidiOut : public RtMidi
+class RTMIDI_DLL_PUBLIC RtMidiOut : public RtMidi
 {
  public:
 

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -70,7 +70,7 @@
 */
 /************************************************************************/
 
-class RtMidiError : public std::exception
+class RTMIDI_DLL_PUBLIC RtMidiError : public std::exception
 {
  public:
   //! Defined RtMidiError types.
@@ -123,7 +123,7 @@ typedef void (*RtMidiErrorCallback)( RtMidiError::Type type, const std::string &
 
 class MidiApi;
 
-class RtMidi
+class RTMIDI_DLL_PUBLIC RtMidi
 {
  public:
 
@@ -468,7 +468,7 @@ class RTMIDI_DLL_PUBLIC RtMidiOut : public RtMidi
 //
 // **************************************************************** //
 
-class MidiApi
+class  RTMIDI_DLL_PUBLIC MidiApi
 {
  public:
 
@@ -499,7 +499,7 @@ protected:
   void *errorCallbackUserData_;
 };
 
-class MidiInApi : public MidiApi
+class RTMIDI_DLL_PUBLIC MidiInApi : public MidiApi
 {
  public:
 
@@ -563,7 +563,7 @@ class MidiInApi : public MidiApi
   RtMidiInData inputData_;
 };
 
-class MidiOutApi : public MidiApi
+class RTMIDI_DLL_PUBLIC MidiOutApi : public MidiApi
 {
  public:
 

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -468,7 +468,7 @@ class RTMIDI_DLL_PUBLIC RtMidiOut : public RtMidi
 //
 // **************************************************************** //
 
-class  RTMIDI_DLL_PUBLIC MidiApi
+class RTMIDI_DLL_PUBLIC MidiApi
 {
  public:
 

--- a/configure.ac
+++ b/configure.ac
@@ -30,11 +30,9 @@ AC_SUBST(SO_VERSION)
 
 # Check version number coherency between RtMidi.h and configure.ac
 AC_MSG_CHECKING([that version numbers are coherent])
-AC_RUN_IFELSE(
-   [AC_LANG_PROGRAM([#include <string.h>
-                     `grep "define RTMIDI_VERSION" $srcdir/RtMidi.h`],
-                    [return strcmp(RTMIDI_VERSION, PACKAGE_VERSION);])],
-   [AC_MSG_RESULT([yes])],
+RTMIDI_VERSION=`sed -n 's/#define RTMIDI_VERSION "\(.*\)"/\1/p' $srcdir/RtMidi.h`
+AS_IF(
+   [test "x$RTMIDI_VERSION" != "x$PACKAGE_VERSION"],
    [AC_MSG_FAILURE([testing RTMIDI_VERSION==PACKAGE_VERSION failed, check that RtMidi.h defines RTMIDI_VERSION as "$PACKAGE_VERSION" or that the first line of configure.ac has been updated.])])
 
 # Enable some nice automake features if they are available

--- a/configure.ac
+++ b/configure.ac
@@ -31,8 +31,6 @@ AC_SUBST(LIBS)
 AC_SUBST(api)
 AC_SUBST(req)
 
-cppflags=""
-cxxflags=""
 api=""
 req=""
 
@@ -41,6 +39,7 @@ GXX="no"
 
 # if the user did not provide any CXXFLAGS, we can override them
 AS_IF([test "x$CXXFLAGS" = "x" ], [override_cxx=yes], [override_cxx=no])
+AS_IF([test "x$CFLAGS" = "x" ], [override_c=yes], [override_c=no])
 
 # Check version number coherency between RtMidi.h and configure.ac
 AC_MSG_CHECKING([that version numbers are coherent])
@@ -87,23 +86,31 @@ AC_CHECK_HEADER([semaphore.h], [
 
 # check for debug
 AC_MSG_CHECKING(whether to compile debug version)
-AS_IF([test "x${enable_debug}" = "xyes" ],[
+debugflags=""
+object_path=Release
+AS_CASE([${enable_debug}],
+  [ yes ], [
     AC_MSG_RESULT([yes])
     CPPFLAGS="-D__RTMIDI_DEBUG ${CPPFLAGS}"
-    cxxflags="${cxxflags} -g"
+    debugflags="${debugflags} -g"
     object_path=Debug
-    ],[
+  ],
+  [ no ], [
+    AC_MSG_RESULT([no!])
+    debugflags="${debugflags} -O3"
+  ], [
     AC_MSG_RESULT([no])
-    cxxflags="${cxxflags} -O3"
-    object_path=Release
   ])
+# For debugging and optimization ... overwrite default because it has both -g and -O2
+AS_IF([test "x$debugflags" != x],
+  AS_IF([test "x$override_cxx" = "xyes" ], CXXFLAGS="$CXXFLAGS $debugflags", CXXFLAGS="$debugflags $CXXFLAGS")
+  AS_IF([test "x$override_c" = "xyes" ], CFLAGS="$CFLAGS $debugflags", CFLAGS="$debugflags $CFLAGS")
+  )
 
 # Check compiler and use -Wall if gnu.
 AS_IF([test "x$GXX" = "xyes"], [
   CXXFLAGS="-Wall -Wextra ${CXXFLAGS}"
 ])
-# For debugging and optimization ... overwrite default because it has both -g and -O2
-AS_IF([test "x$override_cxx" = "xyes" ], CXXFLAGS="$CXXFLAGS $cxxflags", CXXFLAGS="$cxxflags $CXXFLAGS")
 
 # Checks for doxygen
 AC_CHECK_PROG( DOXYGEN, [doxygen], [doxygen] )

--- a/configure.ac
+++ b/configure.ac
@@ -72,11 +72,6 @@ AC_ARG_ENABLE(debug,
   [AC_SUBST( cppflag, [-D__RTMIDI_DEBUG__] ) AC_SUBST( cxxflag, [-g] ) AC_SUBST( object_path, [Debug] ) AC_MSG_RESULT(yes)],
   [AC_SUBST( cppflag, [] ) AC_SUBST( cxxflag, [-O3] ) AC_SUBST( object_path, [Release] ) AC_MSG_RESULT(no)])
 
-# Set paths if prefix is defined
-if test "x$prefix" != "x" && test "x$prefix" != "xNONE"; then
-  LIBS="$LIBS -L$prefix/lib"
-fi
-
 # For -I and -D flags
 CPPFLAGS="$CPPFLAGS $cppflag"
 

--- a/configure.ac
+++ b/configure.ac
@@ -77,16 +77,19 @@ AC_CHECK_HEADER([semaphore.h], [
 ])
 
 # Check for debug
-AC_MSG_CHECKING(whether to compile debug version)
 AC_ARG_ENABLE([debug],
-  [  --enable-debug = enable various debug output], [
+  [  --enable-debug = enable various debug output])
+
+AC_MSG_CHECKING(whether to compile debug version)
+AS_IF([test "x${enable_debug}" = "xyes" ],[
+    AC_MSG_RESULT([yes])
     CPPFLAGS="-D__RTMIDI_DEBUG ${CPPFLAGS}"
     cxxflags="${cxxflags} -g"
     object_path=Debug
-    AC_MSG_RESULT([yes])],[
+    ],[
+    AC_MSG_RESULT([no])
     cxxflags="${cxxflags} -O3"
     object_path=Release
-    AC_MSG_RESULT([no])
   ])
 
 # Check compiler and use -Wall if gnu.

--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,20 @@ m4_define([lt_current_minus_age], [m4_eval(lt_current - lt_age)])
 
 SO_VERSION=lt_version_info
 AC_SUBST(SO_VERSION)
+AC_SUBST(LIBS)
+AC_SUBST(api)
+AC_SUBST(req)
+
+cppflags=""
+cxxflags=""
+api=""
+req=""
+
+# Fill GXX with something before test.
+GXX="no"
+
+# if the user did not provide any CXXFLAGS, we can override them
+AS_IF([test "x$CXXFLAGS" = "x" ], [override_cxx=yes], [override_cxx=no])
 
 # Check version number coherency between RtMidi.h and configure.ac
 AC_MSG_CHECKING([that version numbers are coherent])
@@ -39,17 +53,14 @@ AS_IF(
 m4_ifdef([AM_MAINTAINER_MODE], [AM_MAINTAINER_MODE])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
-# Fill GXX with something before test.
-AC_SUBST( GXX, ["no"] )
-AC_SUBST(noinst_LIBRARIES)
 
 # Checks for programs.
 AC_PROG_CXX(g++ CC c++ cxx)
 AM_PROG_AR
 AC_PATH_PROG(AR, ar, no)
-if [[ $AR = "no" ]] ; then
+AS_IF([test "x$AR" = "xno"], [
     AC_MSG_ERROR("Could not find ar - needed to create a library");
-fi
+])
 
 LT_INIT([win32-dll])
 AC_CONFIG_MACRO_DIR([m4])
@@ -67,24 +78,23 @@ AC_CHECK_HEADER([semaphore.h], [
 
 # Check for debug
 AC_MSG_CHECKING(whether to compile debug version)
-AC_ARG_ENABLE(debug,
-  [  --enable-debug = enable various debug output],
-  [AC_SUBST( cppflag, [-D__RTMIDI_DEBUG__] ) AC_SUBST( cxxflag, [-g] ) AC_SUBST( object_path, [Debug] ) AC_MSG_RESULT(yes)],
-  [AC_SUBST( cppflag, [] ) AC_SUBST( cxxflag, [-O3] ) AC_SUBST( object_path, [Release] ) AC_MSG_RESULT(no)])
-
-# For -I and -D flags
-CPPFLAGS="$CPPFLAGS $cppflag"
-
-# For debugging and optimization ... overwrite default because it has both -g and -O2
-#CXXFLAGS="$CXXFLAGS $cxxflag"
-CXXFLAGS="$cxxflag"
+AC_ARG_ENABLE([debug],
+  [  --enable-debug = enable various debug output], [
+    CPPFLAGS="-D__RTMIDI_DEBUG ${CPPFLAGS}"
+    cxxflags="${cxxflags} -g"
+    object_path=Debug
+    AC_MSG_RESULT([yes])],[
+    cxxflags="${cxxflags} -O3"
+    object_path=Release
+    AC_MSG_RESULT([no])
+  ])
 
 # Check compiler and use -Wall if gnu.
-if [test $GXX = "yes" ;] then
-  AC_SUBST( cxxflag, ["-Wall -Wextra"] )
-fi
-
-CXXFLAGS="$CXXFLAGS $cxxflag"
+AS_IF([test "x$GXX" = "xyes"], [
+  CXXFLAGS="-Wall -Wextra ${CXXFLAGS}"
+])
+# For debugging and optimization ... overwrite default because it has both -g and -O2
+AS_IF([test "x$override_cxx" = "xyes" ], CXXFLAGS="$CXXFLAGS $cxxflags", CXXFLAGS="$cxxflags $CXXFLAGS")
 
 # Checks for doxygen
 AC_CHECK_PROG( DOXYGEN, [doxygen], [doxygen] )
@@ -100,12 +110,10 @@ AC_CONFIG_LINKS( [doc/images/mcgill.gif:doc/images/mcgill.gif] )
 # Checks for package options and external software
 AC_CANONICAL_HOST
 
-AC_SUBST( api, [""] )
-AC_SUBST( req, [""] )
 AC_MSG_CHECKING(for MIDI API)
 
 AC_ARG_WITH(jack, [  --with-jack = choose JACK server support (mac and linux only)])
-AS_IF([test "x$with_jack" == "xyes"], [
+AS_IF([test "x$with_jack" = "xyes"], [
 api="$api -D__UNIX_JACK__"
 AC_MSG_RESULT(using JACK)
 AC_CHECK_LIB(jack, jack_client_open, , AC_MSG_ERROR(JACK support requires the jack library!))])
@@ -114,18 +122,19 @@ case $host in
   *-*-linux*)
   # Look for ALSA flag
   AC_ARG_WITH(alsa, [  --with-alsa = choose native ALSA sequencer API support (linux only)])
-  AS_IF([test "x$with_alsa" == "xyes"], [
+  AS_IF([test "x$with_alsa" = "xyes"], [
+    AC_MSG_RESULT(using ALSA)
+    AC_CHECK_LIB(asound, snd_seq_open, , AC_MSG_ERROR(ALSA support requires the asound library!))
     api="$api -D__LINUX_ALSA__"
     req="$req alsa"
-    AC_MSG_RESULT(using ALSA)
-    AC_CHECK_LIB(asound, snd_seq_open, , AC_MSG_ERROR(ALSA support requires the asound library!))])
+  ])
 
-  if [test "$api" == "";] then
+  AS_IF([test "x${api}" = "x"],
     AC_MSG_RESULT(using ALSA)
-    AC_SUBST( api, [-D__LINUX_ALSA__] )
-    req="$req alsa"
     AC_CHECK_LIB(asound, snd_seq_open, , AC_MSG_ERROR(ALSA sequencer support requires the asound library!))
-  fi
+    api="-D__LINUX_ALSA__ ${api}"
+    req="$req alsa"
+  )
 
   # Checks for pthread library.
   AC_CHECK_LIB(pthread, pthread_create, , AC_MSG_ERROR(RtMidi requires the pthread library!))
@@ -134,47 +143,50 @@ case $host in
   *-apple*)
   # Look for Core flag
   AC_ARG_WITH(core, [  --with-core = choose CoreMidi API support (mac only)])
-  AS_IF([test "x$with_core" == "xyes"], [
-    api="$api -D__MACOSX_CORE__"
+  AS_IF([test "x$with_core" = "xyes"], [
     AC_MSG_RESULT(using CoreMidi)
     AC_CHECK_HEADER(CoreMIDI/CoreMIDI.h, [], [AC_MSG_ERROR(CoreMIDI header files not found!)] )
-    LIBS="$LIBS -framework CoreMIDI -framework CoreFoundation -framework CoreAudio" ])
+    LIBS="-framework CoreMIDI -framework CoreFoundation -framework CoreAudio ${LIBS}"
+    api="$api -D__MACOSX_CORE__"
+  ])
 
   # If no api flags specified, use CoreMidi
-  if [test "$api" == ""; ] then
-    AC_SUBST( api, [-D__MACOSX_CORE__] )
+  AS_IF([test "x${api}" = "x"],
     AC_MSG_RESULT(using CoreMidi)
     AC_CHECK_HEADER(CoreMIDI/CoreMIDI.h,
       [],
       [AC_MSG_ERROR(CoreMIDI header files not found!)] )
-    AC_SUBST( LIBS, ["-framework CoreMIDI -framework CoreFoundation -framework CoreAudio"] )
-  fi
+    LIBS="-framework CoreMIDI -framework CoreFoundation -framework CoreAudio ${LIBS}"
+    api="$api -D__MACOSX_CORE__"
+  )
   ;;
 
   *-mingw32*)
   # Look for WinMM flag
   AC_ARG_WITH(winmm, [  --with-winmm = choose Windows MultiMedia (MM) API support (windoze only)])
-  AS_IF([test "x$with_winmm" == "xyes"], [
-    api="$api -D__WINDOWS_MM__"
+  AS_IF([test "x$with_winmm" = "xyes"], [
     AC_MSG_RESULT(using WinMM)
-    AC_SUBST( LIBS, [-lwinmm] )])
+    LIBS="-lwinmm ${LIBS}"
+    api="$api -D__WINDOWS_MM__"
+  ])
 
   AC_ARG_WITH(winks, [  --with-winks = choose kernel streaming support (windoze only)])
-  AS_IF([test "x$with_winks" == "xyes"], [
+  AS_IF([test "x$with_winks" = "xyes"], [
+    AC_MSG_RESULT(using kernel streaming)
+    LIBS="-lsetupapi -lksuser ${LIBS}"
     api="$api -D__WINDOWS_KS__"
-    AC_SUBST( LIBS, ["-lsetupapi -lksuser"] )
-    AC_MSG_RESULT(using kernel streaming) ])
+  ])
 
   # I can't get the following check to work so just manually add the library
 	# or could try the following?  AC_LIB_WINMM([midiOutGetNumDevs])
   # AC_CHECK_LIB(winmm, midiInGetNumDevs, , AC_MSG_ERROR(Windows MIDI support requires the winmm library!) )],)
 
   # If no api flags specified, use WinMM
-  if [test "$api" == "";] then
-    AC_SUBST( api, [-D__WINDOWS_MM__] )
+  AS_IF([test "x${api}" = "x"], [
     AC_MSG_RESULT(using WinMM)
-    AC_SUBST( LIBS, [-lwinmm] )
-  fi
+    LIBS="-lwinmm ${LIBS}"
+    api="${api} -D__WINDOWS_MM__"
+  ])
   ;;
 
   *)

--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,9 @@ AC_SUBST(SO_VERSION)
 AC_SUBST(LIBS)
 AC_SUBST(api)
 AC_SUBST(req)
+AC_SUBST(visibility)
 
+visibility=""
 api=""
 req=""
 
@@ -110,6 +112,7 @@ AS_IF([test "x$debugflags" != x],
 # Check compiler and use -Wall if gnu.
 AS_IF([test "x$GXX" = "xyes"], [
   CXXFLAGS="-Wall -Wextra ${CXXFLAGS}"
+  AS_IF([test "x${enable_debug}" != "xyes" ], visibility="-fvisibility=hidden" )
 ])
 
 # Checks for doxygen

--- a/configure.ac
+++ b/configure.ac
@@ -67,7 +67,7 @@ AC_PROG_CXX(g++ CC c++ cxx)
 AM_PROG_AR
 AC_PATH_PROG(AR, ar, no)
 AS_IF([test "x$AR" = "xno"], [
-    AC_MSG_ERROR("Could not find ar - needed to create a library");
+    AC_MSG_ERROR([Could not find ar - needed to create a library])
 ])
 
 LT_INIT([win32-dll])

--- a/configure.ac
+++ b/configure.ac
@@ -77,8 +77,7 @@ AC_CHECK_HEADER([semaphore.h], [
 ])
 
 # Check for debug
-AC_ARG_ENABLE([debug],
-  [  --enable-debug = enable various debug output])
+AC_ARG_ENABLE([debug], [AS_HELP_STRING([--enable-debug], [enable various debugging output])])
 
 AC_MSG_CHECKING(whether to compile debug version)
 AS_IF([test "x${enable_debug}" = "xyes" ],[
@@ -115,7 +114,7 @@ AC_CANONICAL_HOST
 
 AC_MSG_CHECKING(for MIDI API)
 
-AC_ARG_WITH(jack, [  --with-jack = choose JACK server support (mac and linux only)])
+AC_ARG_WITH(jack, [AS_HELP_STRING([--with-jack], [choose JACK server support (mac and linux only)])])
 AS_IF([test "x$with_jack" = "xyes"], [
 api="$api -D__UNIX_JACK__"
 AC_MSG_RESULT(using JACK)
@@ -124,7 +123,7 @@ AC_CHECK_LIB(jack, jack_client_open, , AC_MSG_ERROR(JACK support requires the ja
 case $host in
   *-*-linux*)
   # Look for ALSA flag
-  AC_ARG_WITH(alsa, [  --with-alsa = choose native ALSA sequencer API support (linux only)])
+  AC_ARG_WITH(alsa, [AS_HELP_STRING([--with-alsa], [choose native ALSA sequencer API support (linux only)])])
   AS_IF([test "x$with_alsa" = "xyes"], [
     AC_MSG_RESULT(using ALSA)
     AC_CHECK_LIB(asound, snd_seq_open, , AC_MSG_ERROR(ALSA support requires the asound library!))
@@ -145,7 +144,7 @@ case $host in
 
   *-apple*)
   # Look for Core flag
-  AC_ARG_WITH(core, [  --with-core = choose CoreMidi API support (mac only)])
+  AC_ARG_WITH(core, [AS_HELP_STRING([--with-core], [ choose CoreMidi API support (mac only)])])
   AS_IF([test "x$with_core" = "xyes"], [
     AC_MSG_RESULT(using CoreMidi)
     AC_CHECK_HEADER(CoreMIDI/CoreMIDI.h, [], [AC_MSG_ERROR(CoreMIDI header files not found!)] )
@@ -166,14 +165,14 @@ case $host in
 
   *-mingw32*)
   # Look for WinMM flag
-  AC_ARG_WITH(winmm, [  --with-winmm = choose Windows MultiMedia (MM) API support (windoze only)])
+  AC_ARG_WITH(winmm, [AS_HELP_STRING([--with-winmm], [ choose Windows MultiMedia (MM) API support (win32 only)])])
   AS_IF([test "x$with_winmm" = "xyes"], [
     AC_MSG_RESULT(using WinMM)
     LIBS="-lwinmm ${LIBS}"
     api="$api -D__WINDOWS_MM__"
   ])
 
-  AC_ARG_WITH(winks, [  --with-winks = choose kernel streaming support (windoze only)])
+  AC_ARG_WITH(winks, [AS_HELP_STRING([--with-winks], [  choose kernel streaming support (win32 only)])])
   AS_IF([test "x$with_winks" = "xyes"], [
     AC_MSG_RESULT(using kernel streaming)
     LIBS="-lsetupapi -lksuser ${LIBS}"

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,14 @@ AS_IF(
 m4_ifdef([AM_MAINTAINER_MODE], [AM_MAINTAINER_MODE])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
+# configure flags
+AC_ARG_ENABLE([debug], [AS_HELP_STRING([--enable-debug], [enable various debugging output])])
+AC_ARG_WITH(jack, [AS_HELP_STRING([--with-jack], [choose JACK server support (mac and linux only)])])
+AC_ARG_WITH(alsa, [AS_HELP_STRING([--with-alsa], [choose native ALSA sequencer API support (linux only)])])
+AC_ARG_WITH(core, [AS_HELP_STRING([--with-core], [ choose CoreMidi API support (mac only)])])
+AC_ARG_WITH(winmm, [AS_HELP_STRING([--with-winmm], [ choose Windows MultiMedia (MM) API support (win32 only)])])
+AC_ARG_WITH(winks, [AS_HELP_STRING([--with-winks], [  choose kernel streaming support (win32 only)])])
+
 
 # Checks for programs.
 AC_PROG_CXX(g++ CC c++ cxx)
@@ -76,9 +84,8 @@ AC_CHECK_HEADER([semaphore.h], [
     AC_MSG_WARN([POSIX semaphore support not found; data may be lost on closePort]))
 ])
 
-# Check for debug
-AC_ARG_ENABLE([debug], [AS_HELP_STRING([--enable-debug], [enable various debugging output])])
 
+# check for debug
 AC_MSG_CHECKING(whether to compile debug version)
 AS_IF([test "x${enable_debug}" = "xyes" ],[
     AC_MSG_RESULT([yes])
@@ -112,9 +119,11 @@ AC_CONFIG_LINKS( [doc/images/mcgill.gif:doc/images/mcgill.gif] )
 # Checks for package options and external software
 AC_CANONICAL_HOST
 
+
+
+
 AC_MSG_CHECKING(for MIDI API)
 
-AC_ARG_WITH(jack, [AS_HELP_STRING([--with-jack], [choose JACK server support (mac and linux only)])])
 AS_IF([test "x$with_jack" = "xyes"], [
 api="$api -D__UNIX_JACK__"
 AC_MSG_RESULT(using JACK)
@@ -123,7 +132,6 @@ AC_CHECK_LIB(jack, jack_client_open, , AC_MSG_ERROR(JACK support requires the ja
 case $host in
   *-*-linux*)
   # Look for ALSA flag
-  AC_ARG_WITH(alsa, [AS_HELP_STRING([--with-alsa], [choose native ALSA sequencer API support (linux only)])])
   AS_IF([test "x$with_alsa" = "xyes"], [
     AC_MSG_RESULT(using ALSA)
     AC_CHECK_LIB(asound, snd_seq_open, , AC_MSG_ERROR(ALSA support requires the asound library!))
@@ -144,7 +152,6 @@ case $host in
 
   *-apple*)
   # Look for Core flag
-  AC_ARG_WITH(core, [AS_HELP_STRING([--with-core], [ choose CoreMidi API support (mac only)])])
   AS_IF([test "x$with_core" = "xyes"], [
     AC_MSG_RESULT(using CoreMidi)
     AC_CHECK_HEADER(CoreMIDI/CoreMIDI.h, [], [AC_MSG_ERROR(CoreMIDI header files not found!)] )
@@ -165,14 +172,12 @@ case $host in
 
   *-mingw32*)
   # Look for WinMM flag
-  AC_ARG_WITH(winmm, [AS_HELP_STRING([--with-winmm], [ choose Windows MultiMedia (MM) API support (win32 only)])])
   AS_IF([test "x$with_winmm" = "xyes"], [
     AC_MSG_RESULT(using WinMM)
     LIBS="-lwinmm ${LIBS}"
     api="$api -D__WINDOWS_MM__"
   ])
 
-  AC_ARG_WITH(winks, [AS_HELP_STRING([--with-winks], [  choose kernel streaming support (win32 only)])])
   AS_IF([test "x$with_winks" = "xyes"], [
     AC_MSG_RESULT(using kernel streaming)
     LIBS="-lsetupapi -lksuser ${LIBS}"

--- a/rtmidi.pc.in
+++ b/rtmidi.pc.in
@@ -9,4 +9,4 @@ Version: @PACKAGE_VERSION@
 Requires: @req@ 
 Libs: -L${libdir} -lrtmidi
 Libs.private: -lpthread
-Cflags: -pthread -I${includedir} @CPPFLAGS@
+Cflags: -pthread -I${includedir} @api@


### PR DESCRIPTION
this includes the Debian patches from #131.
the original patches have been broken up and re-submitted in what i think are more atomic pieces.
some of the more dubious parts of the patches have been removed entirely (e.g. the `PC_FILE` stuff).

things that still need to be resolved:
- [x] enable "-fvisibility=hidden" by default (via some configure check/option)
- [x] get the `cppflags` handling right to support `--enable-debug`