### PR TITLE
Revert "Enabled visibility=hidden for non-debug builds (only)"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,8 +3,6 @@ if MAKE_DOC
 SUBDIRS += doc
 endif
 
-AM_CXXFLAGS = @visibility@
-
 lib_LTLIBRARIES = %D%/librtmidi.la
 %C%_librtmidi_la_LDFLAGS = -no-undefined -export-dynamic -version-info @SO_VERSION@
 %C%_librtmidi_la_SOURCES = \

--- a/configure.ac
+++ b/configure.ac
@@ -30,9 +30,7 @@ AC_SUBST(SO_VERSION)
 AC_SUBST(LIBS)
 AC_SUBST(api)
 AC_SUBST(req)
-AC_SUBST(visibility)
 
-visibility=""
 api=""
 req=""
 
@@ -112,7 +110,6 @@ AS_IF([test "x$debugflags" != x],
 # Check compiler and use -Wall if gnu.
 AS_IF([test "x$GXX" = "xyes"], [
   CXXFLAGS="-Wall -Wextra ${CXXFLAGS}"
-  AS_IF([test "x${enable_debug}" != "xyes" ], visibility="-fvisibility=hidden" )
 ])
 
 # Checks for doxygen


### PR DESCRIPTION
This reverts commit 0470e7c5e5fc70ca22351883cab76c8e1222438a.

I have found that with this change, the resulting `.libs/librtmidi.dylib` doesn't seem to expose the C-API methods when being invoked using P/Invoke from .Net Core managed code.

Reverting this specific commit, seems to "fix" the issue. As after this, my code again starts working and P/Invoke again is able to invoke the methods.

See this issue for further discussion https://github.com/thestk/rtmidi/issues/137