### PR TITLE
add setClientName() functionality

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -93,6 +93,12 @@ void RtMidi :: getCompiledApi( std::vector<RtMidi::Api> &apis ) throw()
 #endif
 }
 
+void RtMidi :: setClientName( const std::string &clientName )
+{
+  rtapi_->setClientName(clientName);
+}
+
+
 //*********************************************************************//
 //  RtMidiIn Definitions
 //*********************************************************************//
@@ -748,6 +754,14 @@ void MidiInCore :: closePort( void )
   connected_ = false;
 }
 
+void MidiInCore :: setClientName ( const std::string& )
+{
+
+  errorString_ = "MidiInCore::setClientName: this function is not implemented for the MACOSX_CORE API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
 unsigned int MidiInCore :: getPortCount()
 {
   CFRunLoopRunInMode( kCFRunLoopDefaultMode, 0, false );
@@ -1047,6 +1061,14 @@ void MidiOutCore :: closePort( void )
   }
 
   connected_ = false;
+}
+
+void MidiOutCore :: setClientName ( const std::string& )
+{
+
+  errorString_ = "MidiOutCore::setClientName: this function is not implemented for the MACOSX_CORE API!";
+  error( RtMidiError::WARNING, errorString_ );
+
 }
 
 void MidiOutCore :: openVirtualPort( const std::string &portName )
@@ -1740,6 +1762,14 @@ void MidiInAlsa :: closePort( void )
   }
 }
 
+void MidiInAlsa :: setClientName( const std::string &clientName )
+{
+
+    AlsaMidiData *data = static_cast<AlsaMidiData *> ( apiData_ );
+    snd_seq_set_client_name( data->seq, clientName.c_str() );
+
+}
+
 //*********************************************************************//
 //  API: LINUX ALSA
 //  Class Definitions: MidiOutAlsa
@@ -1917,6 +1947,14 @@ void MidiOutAlsa :: closePort( void )
     data->subscription = 0;
     connected_ = false;
   }
+}
+
+void MidiOutAlsa :: setClientName( const std::string &clientName )
+{
+
+    AlsaMidiData *data = static_cast<AlsaMidiData *> ( apiData_ );
+    snd_seq_set_client_name( data->seq, clientName.c_str() );
+
 }
 
 void MidiOutAlsa :: openVirtualPort( const std::string &portName )
@@ -2292,6 +2330,14 @@ void MidiInWinMM :: closePort( void )
   }
 }
 
+void MidiInWinMM :: setClientName ( const std::string& )
+{
+
+  errorString_ = "MidiInWinMM::setClientName: this function is not implemented for the WINDOWS_MM API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
 unsigned int MidiInWinMM :: getPortCount()
 {
   return midiInGetNumDevs();
@@ -2442,6 +2488,14 @@ void MidiOutWinMM :: closePort( void )
     data->outHandle = 0;
     connected_ = false;
   }
+}
+
+void MidiOutWinMM :: setClientName ( const std::string& )
+{
+
+  errorString_ = "MidiOutWinMM::setClientName: this function is not implemented for the WINDOWS_MM API!";
+  error( RtMidiError::WARNING, errorString_ );
+
 }
 
 void MidiOutWinMM :: openVirtualPort( const std::string &/*portName*/ )
@@ -2758,6 +2812,14 @@ void MidiInJack :: closePort()
   data->port = NULL;
 }
 
+void MidiInJack:: setClientName( const std::string& )
+{
+
+  errorString_ = "MidiInJack::setClientName: this function is not implemented for the UNIX_JACK API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
 //*********************************************************************//
 //  API: JACK
 //  Class Definitions: MidiOutJack
@@ -2959,6 +3021,14 @@ void MidiOutJack :: closePort()
 
   jack_port_unregister( data->client, data->port );
   data->port = NULL;
+}
+
+void MidiOutJack:: setClientName( const std::string& )
+{
+
+  errorString_ = "MidiOutJack::setClientName: this function is not implemented for the UNIX_JACK API!";
+  error( RtMidiError::WARNING, errorString_ );
+
 }
 
 void MidiOutJack :: sendMessage( const unsigned char *message, size_t size )

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -163,6 +163,8 @@ class RTMIDI_DLL_PUBLIC RtMidi
   //! Pure virtual closePort() function.
   virtual void closePort( void ) = 0;
 
+  void setClientName( const std::string &clientName );
+
   //! Returns true if a port is open and false if not.
   /*!
       Note that this only applies to connections made with the openPort()
@@ -478,6 +480,7 @@ class RTMIDI_DLL_PUBLIC MidiApi
   virtual void openPort( unsigned int portNumber, const std::string &portName ) = 0;
   virtual void openVirtualPort( const std::string &portName ) = 0;
   virtual void closePort( void ) = 0;
+  virtual void setClientName( const std::string &clientName ) = 0;
 
   virtual unsigned int getPortCount( void ) = 0;
   virtual std::string getPortName( unsigned int portNumber ) = 0;
@@ -623,6 +626,7 @@ class MidiInCore: public MidiInApi
   void openPort( unsigned int portNumber, const std::string &portName );
   void openVirtualPort( const std::string &portName );
   void closePort( void );
+  void setClientName( const std::string &clientName );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
 
@@ -639,6 +643,7 @@ class MidiOutCore: public MidiOutApi
   void openPort( unsigned int portNumber, const std::string &portName );
   void openVirtualPort( const std::string &portName );
   void closePort( void );
+  void setClientName( const std::string &clientName );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
   void sendMessage( const unsigned char *message, size_t size );
@@ -660,6 +665,7 @@ class MidiInJack: public MidiInApi
   void openPort( unsigned int portNumber, const std::string &portName );
   void openVirtualPort( const std::string &portName );
   void closePort( void );
+  void setClientName( const std::string &clientName );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
 
@@ -679,6 +685,7 @@ class MidiOutJack: public MidiOutApi
   void openPort( unsigned int portNumber, const std::string &portName );
   void openVirtualPort( const std::string &portName );
   void closePort( void );
+  void setClientName( const std::string &clientName );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
   void sendMessage( const unsigned char *message, size_t size );
@@ -703,6 +710,7 @@ class MidiInAlsa: public MidiInApi
   void openPort( unsigned int portNumber, const std::string &portName );
   void openVirtualPort( const std::string &portName );
   void closePort( void );
+  void setClientName( const std::string &clientName );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
 
@@ -719,6 +727,7 @@ class MidiOutAlsa: public MidiOutApi
   void openPort( unsigned int portNumber, const std::string &portName );
   void openVirtualPort( const std::string &portName );
   void closePort( void );
+  void setClientName( const std::string &clientName );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
   void sendMessage( const unsigned char *message, size_t size );
@@ -740,6 +749,7 @@ class MidiInWinMM: public MidiInApi
   void openPort( unsigned int portNumber, const std::string &portName );
   void openVirtualPort( const std::string &portName );
   void closePort( void );
+  void setClientName( const std::string &clientName );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
 
@@ -756,6 +766,7 @@ class MidiOutWinMM: public MidiOutApi
   void openPort( unsigned int portNumber, const std::string &portName );
   void openVirtualPort( const std::string &portName );
   void closePort( void );
+  void setClientName( const std::string &clientName );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
   void sendMessage( const unsigned char *message, size_t size );
@@ -776,6 +787,7 @@ class MidiInDummy: public MidiInApi
   void openPort( unsigned int /*portNumber*/, const std::string &/*portName*/ ) {}
   void openVirtualPort( const std::string &/*portName*/ ) {}
   void closePort( void ) {}
+  void setClientName( const std::string &/*clientName*/ ) {};
   unsigned int getPortCount( void ) { return 0; }
   std::string getPortName( unsigned int /*portNumber*/ ) { return ""; }
 
@@ -791,6 +803,7 @@ class MidiOutDummy: public MidiOutApi
   void openPort( unsigned int /*portNumber*/, const std::string &/*portName*/ ) {}
   void openVirtualPort( const std::string &/*portName*/ ) {}
   void closePort( void ) {}
+  void setClientName( const std::string &/*clientName*/ ) {};
   unsigned int getPortCount( void ) { return 0; }
   std::string getPortName( unsigned int /*portNumber*/ ) { return ""; }
   void sendMessage( const unsigned char * /*message*/, size_t /*size*/ ) {}


### PR DESCRIPTION
The ALSA Sequencer API supports the re-setting of the client name after
the client has been created. JACK doesn't appear to support this yet
(though there way be a way using the metadata API). Other API's may
support this, but haven't been tested. This commit adds the method
setClientName(const std::string &clientName) to the RtMidi class. For
the API's for which this has not been implemented, a warning is thrown
using the RtMidiError system.