### PR TITLE
make sure to initialize the WinMM mutex

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -2477,6 +2477,7 @@ void MidiInWinMM :: initialize( const std::string& /*clientName*/ )
   if ( !InitializeCriticalSectionAndSpinCount(&(data->_mutex), 0x00000400) ) {
     errorString_ = "MidiInWinMM::initialize: InitializeCriticalSectionAndSpinCount failed.";
     error( RtMidiError::WARNING, errorString_ );
+    InitializeCriticalSection(&(data->_mutex));
   }
 }
 


### PR DESCRIPTION
In the context of Windows 98, the function call `InitializeCriticalSectionAndSpinCount` fails for me, and the warning message is displayed.

I suppose adding `InitializeCriticalSection` can be an adequate fallback in case the mutex fails to initialize in the preferred manner.