### PR TITLE
API names, and conversion from/to API identifier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ if(BUILD_SHARED_LIBS)
 
   # Set compile-time definitions
   target_compile_definitions(rtmidi PRIVATE ${API_DEFS})
+  target_compile_definitions(rtmidi PRIVATE RTMIDI_EXPORT)
 
   target_link_libraries(rtmidi ${LINKLIBS})
 endif()
@@ -189,8 +190,9 @@ if(BUILD_TESTING)
   add_executable(midiprobe  tests/midiprobe.cpp)
   add_executable(qmidiin    tests/qmidiin.cpp)
   add_executable(sysextest  tests/sysextest.cpp)
+  add_executable(apinames   tests/apinames.cpp)
   list(GET LIB_TARGETS 0 LIBRTMIDI)
-  set_target_properties(cmidiin midiclock midiout midiprobe qmidiin sysextest
+  set_target_properties(cmidiin midiclock midiout midiprobe qmidiin sysextest apinames
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY tests
                INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}
                LINK_LIBRARIES ${LIBRTMIDI})

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,6 +4,7 @@ SUBDIRS += doc
 endif
 
 lib_LTLIBRARIES = %D%/librtmidi.la
+%C%_librtmidi_la_CXXFLAGS = -DRTMIDI_EXPORT
 %C%_librtmidi_la_LDFLAGS = -no-undefined -export-dynamic -version-info @SO_VERSION@
 %C%_librtmidi_la_SOURCES = \
   %D%/RtMidi.cpp \

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -44,7 +44,11 @@
 #define RTMIDI_H
 
 #if defined _WIN32 || defined __CYGWIN__
-  #define RTMIDI_DLL_PUBLIC
+  #if defined(RTMIDI_EXPORT)
+    #define RTMIDI_DLL_PUBLIC __declspec(dllexport)
+  #else
+    #define RTMIDI_DLL_PUBLIC
+  #endif
 #else
   #if __GNUC__ >= 4
     #define RTMIDI_DLL_PUBLIC __attribute__( (visibility( "default" )) )
@@ -134,7 +138,8 @@ class RTMIDI_DLL_PUBLIC RtMidi
     LINUX_ALSA,     /*!< The Advanced Linux Sound Architecture API. */
     UNIX_JACK,      /*!< The JACK Low-Latency MIDI Server API. */
     WINDOWS_MM,     /*!< The Microsoft Multimedia MIDI API. */
-    RTMIDI_DUMMY    /*!< A compilable but non-functional API. */
+    RTMIDI_DUMMY,   /*!< A compilable but non-functional API. */
+    NUM_APIS        /*!< Number of values in this enum. */
   };
 
   //! A static function to determine the current RtMidi version.
@@ -147,6 +152,29 @@ class RTMIDI_DLL_PUBLIC RtMidi
     API compiled for certain operating systems.
   */
   static void getCompiledApi( std::vector<RtMidi::Api> &apis ) throw();
+
+  //! Return the name of a specified compiled MIDI API.
+  /*!
+    This obtains a short lower-case name used for identification purposes.
+    This value is guaranteed to remain identical across library versions.
+    If the API is unknown, this function will return the empty string.
+  */
+  static std::string getApiName( RtMidi::Api api );
+
+  //! Return the display name of a specified compiled MIDI API.
+  /*!
+    This obtains a long name used for display purposes.
+    If the API is unknown, this function will return the empty string.
+  */
+  static std::string getApiDisplayName( RtMidi::Api api );
+
+  //! Return the compiled MIDI API having the given name.
+  /*!
+    A case insensitive comparison will check the specified name
+    against the list of compiled APIs, and return the one which
+    matches. On failure, the function returns UNSPECIFIED.
+  */
+  static RtMidi::Api getCompiledApiByName( const std::string &name );
 
   //! Pure virtual openPort() function.
   virtual void openPort( unsigned int portNumber = 0, const std::string &portName = std::string( "RtMidi" ) ) = 0;

--- a/rtmidi_c.cpp
+++ b/rtmidi_c.cpp
@@ -42,23 +42,40 @@ class CallbackProxyUserData
 	void *user_data;
 };
 
+extern "C" const enum RtMidiApi rtmidi_compiled_apis[]; // casting from RtMidi::Api[]
+extern "C" const unsigned int rtmidi_num_compiled_apis;
+
 /* RtMidi API */
 int rtmidi_get_compiled_api (enum RtMidiApi *apis, unsigned int apis_size)
 {
-    std::vector<RtMidi::Api> v;
-    try {
-        RtMidi::getCompiledApi(v);
-    } catch (...) {
-        return -1;
-    }
+    unsigned num = rtmidi_num_compiled_apis;
     if (apis) {
-        unsigned int i;
-        for (i = 0; i < v.size() && i < apis_size; i++)
-            apis[i] = (RtMidiApi) v[i];
-        return (int)i;
+        num = (num < apis_size) ? num : apis_size;
+        memcpy(apis, rtmidi_compiled_apis, num * sizeof(enum RtMidiApi));
     }
-    // return length for NULL argument.
-    return v.size();
+    return (int)num;
+}
+
+extern "C" const char* rtmidi_api_names[][2];
+const char *rtmidi_api_name(enum RtMidiApi api) {
+    if (api < 0 || api >= RT_MIDI_API_NUM)
+        return NULL;
+    return rtmidi_api_names[api][0];
+}
+
+const char *rtmidi_api_display_name(enum RtMidiApi api)
+{
+    if (api < 0 || api >= RT_MIDI_API_NUM)
+        return "Unknown";
+    return rtmidi_api_names[api][1];
+}
+
+enum RtMidiApi rtmidi_compiled_api_by_name(const char *name) {
+    RtMidi::Api api = RtMidi::UNSPECIFIED;
+    if (name) {
+        api = RtMidi::getCompiledApiByName(name);
+    }
+    return (enum RtMidiApi)api;
 }
 
 void rtmidi_error (MidiApi *api, enum RtMidiErrorType type, const char* errorString)

--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -5,7 +5,11 @@
 #define RTMIDI_C_H
 
 #if defined(RTMIDI_EXPORT)
+#if defined _WIN32 || defined __CYGWIN__
 #define RTMIDIAPI __declspec(dllexport)
+#else
+#define RTMIDIAPI __attribute__((visibility("default")))
+#endif
 #else
 #define RTMIDIAPI //__declspec(dllimport)
 #endif
@@ -43,7 +47,8 @@ enum RtMidiApi {
     RT_MIDI_API_LINUX_ALSA,     /*!< The Advanced Linux Sound Architecture API. */
     RT_MIDI_API_UNIX_JACK,      /*!< The Jack Low-Latency MIDI Server API. */
     RT_MIDI_API_WINDOWS_MM,     /*!< The Microsoft Multimedia MIDI API. */
-    RT_MIDI_API_RTMIDI_DUMMY    /*!< A compilable but non-functional API. */
+    RT_MIDI_API_RTMIDI_DUMMY,   /*!< A compilable but non-functional API. */
+    RT_MIDI_API_NUM             /*!< Number of values in this enum. */
   };
 
 enum RtMidiErrorType {
@@ -74,6 +79,15 @@ typedef void(* RtMidiCCallback) (double timeStamp, const unsigned char* message,
  *         return value indicates an error.
 */
 RTMIDIAPI int rtmidi_get_compiled_api (enum RtMidiApi *apis, unsigned int apis_size);
+
+//! Return the name of a specified compiled MIDI API.
+RTMIDIAPI const char *rtmidi_api_name(enum RtMidiApi api);
+
+//! Return the display name of a specified compiled MIDI API.
+RTMIDIAPI const char *rtmidi_api_display_name(enum RtMidiApi api);
+
+//! Return the compiled MIDI API having the given name.
+RTMIDIAPI enum RtMidiApi rtmidi_compiled_api_by_name(const char *name);
 
 //! Report an error.
 RTMIDIAPI void rtmidi_error (enum RtMidiErrorType type, const char* errorString);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,5 @@
 
-noinst_PROGRAMS = midiprobe midiout qmidiin cmidiin sysextest midiclock_in midiclock_out
+noinst_PROGRAMS = midiprobe midiout qmidiin cmidiin sysextest midiclock_in midiclock_out apinames
 
 AM_CXXFLAGS = -Wall -I$(top_srcdir)
 
@@ -23,6 +23,9 @@ midiclock_in_LDADD = $(top_builddir)/librtmidi.la
 
 midiclock_out_SOURCES = midiclock.cpp
 midiclock_out_LDADD = $(top_builddir)/librtmidi.la
+
+apinames_SOURCES = apinames.cpp
+apinames_LDADD = $(top_builddir)/librtmidi.la
 
 EXTRA_DIST = cmidiin.dsp midiout.dsp midiprobe.dsp qmidiin.dsp	\
 	sysextest.dsp RtMidi.dsw

--- a/tests/apinames.cpp
+++ b/tests/apinames.cpp
@@ -1,0 +1,159 @@
+/******************************************/
+/*
+  apinames.cpp
+  by Jean Pierre Cimalando, 2018.
+
+  This program tests parts of RtMidi related
+  to API names, the conversion from name to API
+  and vice-versa.
+*/
+/******************************************/
+
+#include "RtMidi.h"
+#include <cctype>
+#include <cstdlib>
+#include <iostream>
+
+int test_cpp() {
+    std::vector<RtMidi::Api> apis;
+    RtMidi::getCompiledApi( apis );
+
+    // ensure the known APIs return valid names
+    std::cout << "API names by identifier (C++):\n";
+    for ( size_t i = 0; i < apis.size() ; ++i ) {
+        const std::string name = RtMidi::getApiName(apis[i]);
+        if (name.empty()) {
+            std::cout << "Invalid name for API " << (int)apis[i] << "\n";
+            exit(1);
+        }
+        const std::string displayName = RtMidi::getApiDisplayName(apis[i]);
+        if (displayName.empty()) {
+            std::cout << "Invalid display name for API " << (int)apis[i] << "\n";
+            exit(1);
+        }
+        std::cout << "* " << (int)apis[i] << " '" << name << "': '" << displayName << "'\n";
+    }
+
+    // ensure unknown APIs return the empty string
+    {
+        const std::string name = RtMidi::getApiName((RtMidi::Api)-1);
+        if (!name.empty()) {
+            std::cout << "Bad string for invalid API '" << name << "'\n";
+            exit(1);
+        }
+        const std::string displayName = RtMidi::getApiDisplayName((RtMidi::Api)-1);
+        if (displayName!="Unknown") {
+            std::cout << "Bad display string for invalid API '" << displayName << "'\n";
+            exit(1);
+        }
+    }
+
+    // try getting API identifier by name
+    std::cout << "API identifiers by name (C++):\n";
+    for ( size_t i = 0; i < apis.size() ; ++i ) {
+        std::string name = RtMidi::getApiName(apis[i]);
+        if ( RtMidi::getCompiledApiByName(name) != apis[i] ) {
+            std::cout << "Bad identifier for API '" << name << "'\n";
+            exit( 1 );
+        }
+        std::cout << "* '" << name << "': " << (int)apis[i] << "\n";
+
+        for ( size_t j = 0; j < name.size(); ++j )
+            name[j] = (j & 1) ? toupper(name[j]) : tolower(name[j]);
+        RtMidi::Api api = RtMidi::getCompiledApiByName(name);
+        if ( api != RtMidi::UNSPECIFIED ) {
+            std::cout << "Identifier " << (int)api << " for invalid API '" << name << "'\n";
+            exit( 1 );
+        }
+    }
+
+    // try getting an API identifier by unknown name
+    {
+        RtMidi::Api api;
+        api = RtMidi::getCompiledApiByName("");
+        if ( api != RtMidi::UNSPECIFIED ) {
+            std::cout << "Bad identifier for unknown API name\n";
+            exit( 1 );
+        }
+    }
+
+    return 0;
+}
+
+#include "rtmidi_c.h"
+
+int test_c() {
+    unsigned api_count = rtmidi_get_compiled_api(NULL, 0);
+    std::vector<RtMidiApi> apis(api_count);
+    rtmidi_get_compiled_api(apis.data(), api_count);
+
+    // ensure the known APIs return valid names
+    std::cout << "API names by identifier (C):\n";
+    for ( size_t i = 0; i < api_count; ++i) {
+        const std::string name = rtmidi_api_name(apis[i]);
+        if (name.empty()) {
+            std::cout << "Invalid name for API " << (int)apis[i] << "\n";
+            exit(1);
+        }
+        const std::string displayName = rtmidi_api_display_name(apis[i]);
+        if (displayName.empty()) {
+            std::cout << "Invalid display name for API " << (int)apis[i] << "\n";
+            exit(1);
+        }
+        std::cout << "* " << (int)apis[i] << " '" << name << "': '" << displayName << "'\n";
+    }
+
+    // ensure unknown APIs return the empty string
+    {
+        const char *s = rtmidi_api_name((RtMidiApi)-1);
+        const std::string name(s?s:"");
+        if (!name.empty()) {
+            std::cout << "Bad string for invalid API '" << name << "'\n";
+            exit(1);
+        }
+        s = rtmidi_api_display_name((RtMidiApi)-1);
+        const std::string displayName(s?s:"");
+        if (displayName!="Unknown") {
+            std::cout << "Bad display string for invalid API '" << displayName << "'\n";
+            exit(1);
+        }
+    }
+
+    // try getting API identifier by name
+    std::cout << "API identifiers by name (C):\n";
+    for ( size_t i = 0; i < api_count ; ++i ) {
+        const char *s = rtmidi_api_name(apis[i]);
+        std::string name(s?s:"");
+        if ( rtmidi_compiled_api_by_name(name.c_str()) != apis[i] ) {
+            std::cout << "Bad identifier for API '" << name << "'\n";
+            exit( 1 );
+        }
+        std::cout << "* '" << name << "': " << (int)apis[i] << "\n";
+
+        for ( size_t j = 0; j < name.size(); ++j )
+            name[j] = (j & 1) ? toupper(name[j]) : tolower(name[j]);
+        RtMidiApi api = rtmidi_compiled_api_by_name(name.c_str());
+        if ( api != RT_MIDI_API_UNSPECIFIED ) {
+            std::cout << "Identifier " << (int)api << " for invalid API '" << name << "'\n";
+            exit( 1 );
+        }
+    }
+
+    // try getting an API identifier by unknown name
+    {
+        RtMidiApi api;
+        api = rtmidi_compiled_api_by_name("");
+        if ( api != RT_MIDI_API_UNSPECIFIED ) {
+            std::cout << "Bad identifier for unknown API name\n";
+            exit( 1 );
+        }
+    }
+
+    return 0;
+}
+
+int main()
+{
+    test_cpp();
+    test_c();
+}


### PR DESCRIPTION
This is identical to a proposed enhancement for RtAudio.  https://github.com/thestk/rtaudio/pull/136
In short: it's an ability to get API names, and to look up APIs according to names.

Only difference: the C interface has different signature for querying the APIs.
The implementation and the test have received a minor modification.