### PR TITLE
Fix some bad timestamps on ALSA

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1600,27 +1600,13 @@ static void *alsaMidiHandler( void *ptr )
           // Method 2: Use the ALSA sequencer event time data.
           // (thanks to Pedro Lopez-Cabanillas!).
 
-          // Using method from:
-          // https://www.gnu.org/software/libc/manual/html_node/Elapsed-Time.html
-
-          // Perform the carry for the later subtraction by updating y.
-          snd_seq_real_time_t &x(ev->time.time);
-          snd_seq_real_time_t &y(apiData->lastTime);
-          if (x.tv_nsec < y.tv_nsec) {
-              int nsec = (y.tv_nsec - x.tv_nsec) / 1000000000 + 1;
-              y.tv_nsec -= 1000000000 * nsec;
-              y.tv_sec += nsec;
-          }
-          if (x.tv_nsec - y.tv_nsec > 1000000000) {
-              int nsec = (x.tv_nsec - y.tv_nsec) / 1000000000;
-              y.tv_nsec += 1000000000 * nsec;
-              y.tv_sec -= nsec;
-          }
+          snd_seq_real_time_t x = ev->time.time;
+          snd_seq_real_time_t y = apiData->lastTime;
 
           // Compute the time difference.
-          time = x.tv_sec - y.tv_sec + (x.tv_nsec - y.tv_nsec)*1e-9;
+          time = (x.tv_sec + 1e-9 * x.tv_nsec) - (y.tv_sec + 1e-9 * y.tv_nsec);
 
-          apiData->lastTime = ev->time.time;
+          apiData->lastTime = x;
 
           if ( data->firstMessage == true )
             data->firstMessage = false;


### PR DESCRIPTION
The ALSA interface emits some very high timestamps which are produced as a result of integer overflow in the calculation.
By playback of large numbers of MIDI files into RtMidi's ALSA client, I find such occurrences of the issue to happen extremely frequently, usually within first seconds of playback.

This is the reason: a computation applies a substraction principle from `timespec` values originating from GNU documention. Probably nothing is wrong with this method, but this is the deal. Compare:

```
typedef struct snd_seq_real_time {
        unsigned int tv_sec;            /**< seconds */
        unsigned int tv_nsec;           /**< nanoseconds */
} snd_seq_real_time_t;
```

```
struct timespec {
  time_t tv_sec; /* Seconds.  */
  long tv_nsec;  /* Nanoseconds.  */
};
```

As you can observe, ALSA's variant of timespec stores its nanosecond time as unsigned value.
When the substraction method puts a negative in the nanosecond field, it usually overflows into unsigned value in the measure of billions, which doesn't do well in the timestamp computation following.

I think a simple fix can be as proposed, doing all the computation in floating points where is eliminated any possibility of overflow.