### PR TITLE
correct C no-arg function prototypes

### DIFF
--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -107,7 +107,7 @@ RTMIDIAPI const char* rtmidi_get_port_name (RtMidiPtr device, unsigned int portN
 /* RtMidiIn API */
 
 //! Create a default RtMidiInPtr value, with no initialization.
-RTMIDIAPI RtMidiInPtr rtmidi_in_create_default ();
+RTMIDIAPI RtMidiInPtr rtmidi_in_create_default (void);
 
 /*! Create a  RtMidiInPtr value, with given api, clientName and queueSizeLimit.
  *
@@ -149,7 +149,7 @@ RTMIDIAPI double rtmidi_in_get_message (RtMidiInPtr device, unsigned char *messa
 /* RtMidiOut API */
 
 //! Create a default RtMidiInPtr value, with no initialization.
-RTMIDIAPI RtMidiOutPtr rtmidi_out_create_default ();
+RTMIDIAPI RtMidiOutPtr rtmidi_out_create_default (void);
 
 /*! Create a RtMidiOutPtr value, with given and clientName.
  *


### PR DESCRIPTION
I'm using libclang to parse the header, and it's getting confused by the protos for the two "no argument" functions.

This change won't affect the behaviour at all, but is apparently [more correct, for C at least](https://stackoverflow.com/questions/693788/is-it-better-to-use-c-void-arguments-void-foovoid-or-not-void-foo), and will help libclang parse the header file cleanly.