### PR TITLE
Fix the input of system-exclusive messages on ALSA

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1567,6 +1567,7 @@ static void *alsaMidiHandler( void *ptr )
           break;
         }
       }
+      doDecode = true;
       break;
 
     default:

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1555,7 +1555,7 @@ static void *alsaMidiHandler( void *ptr )
       if ( !( data->ignoreFlags & 0x04 ) ) doDecode = true;
       break;
 
-		case SND_SEQ_EVENT_SYSEX:
+    case SND_SEQ_EVENT_SYSEX:
       if ( (data->ignoreFlags & 0x01) ) break;
       if ( ev->data.ext.len > apiData->bufferSize ) {
         apiData->bufferSize = ev->data.ext.len;


### PR DESCRIPTION
This repairs a problem introduced by commit 3155671
"alsa: fix a switch fallthrough warning", which makes it impossible to
receive any system-exclusive message.