### PR TITLE
jack: track the current port state, fix isPortOpen()

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -3017,6 +3017,8 @@ void MidiInJack :: openPort( unsigned int portNumber, const std::string &portNam
   // Connecting to the output
   std::string name = getPortName( portNumber );
   jack_connect( data->client, name.c_str(), jack_port_name( data->port ) );
+
+  connected_ = true;
 }
 
 void MidiInJack :: openVirtualPort( const std::string &portName )
@@ -3093,6 +3095,8 @@ void MidiInJack :: closePort()
   if ( data->port == NULL ) return;
   jack_port_unregister( data->client, data->port );
   data->port = NULL;
+
+  connected_ = false;
 }
 
 void MidiInJack:: setClientName( const std::string& )
@@ -3228,6 +3232,8 @@ void MidiOutJack :: openPort( unsigned int portNumber, const std::string &portNa
   // Connecting to the output
   std::string name = getPortName( portNumber );
   jack_connect( data->client, jack_port_name( data->port ), name.c_str() );
+
+  connected_ = true;
 }
 
 void MidiOutJack :: openVirtualPort( const std::string &portName )
@@ -3314,6 +3320,8 @@ void MidiOutJack :: closePort()
 
   jack_port_unregister( data->client, data->port );
   data->port = NULL;
+
+  connected_ = false;
 }
 
 void MidiOutJack:: setClientName( const std::string& )


### PR DESCRIPTION
The function `isPortOpen()` always returns `false` on JACK because the member variable `connected_` is never set.
I make it behave the same as other APIs : set to `true` after a non-virtual port opened, `false` after closed.