### PR TITLE
 Allow WinMM users to select RT_SYSEX_BUFFER_SIZE for each port.

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -2386,7 +2386,10 @@ static std::string ConvertToUTF8(const TCHAR *str)
   return u8str;
 }
 
-#define  RT_SYSEX_BUFFER_SIZE 1024
+static size_t RT_SYSEX_BUFFER_SIZE = 1024;
+void setRTSysExBufferSize( size_t size ) {
+  RT_SYSEX_BUFFER_SIZE = size;
+}
 #define  RT_SYSEX_BUFFER_COUNT 4
 
 // A structure to hold variables related to the CoreMIDI API

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -598,6 +598,16 @@ class RTMIDI_DLL_PUBLIC MidiOutApi : public MidiApi
 
 // **************************************************************** //
 //
+// On Windows with the WinMM API, set the size of input buffers
+// created by subsequent calls to openPort(). The default is 1024.
+//
+// **************************************************************** //
+#if defined(__WINDOWS_MM__)
+void setRTSysExBufferSize( size_t size );
+#endif
+
+// **************************************************************** //
+//
 // Inline RtMidiIn and RtMidiOut definitions.
 //
 // **************************************************************** //

--- a/doc/doxygen/tutorial.txt
+++ b/doc/doxygen/tutorial.txt
@@ -397,7 +397,7 @@ The RtMidi JACK support can be compiled on Macintosh OS-X systems, as well as in
 
 The \c configure script provides support for the MinGW compiler.
 
-The Windows Multimedia library MIDI calls used in RtMidi do not make use of streaming functionality.   Incoming system exclusive messages read by RtMidiIn are limited to a length as defined by the preprocessor definition RT_SYSEX_BUFFER_SIZE (set in RtMidi.cpp).  The default value is 1024.  There is no such limit for outgoing sysex messages via RtMidiOut.
+The Windows Multimedia library MIDI calls used in RtMidi do not make use of streaming functionality.   Incoming system exclusive messages read by RtMidiIn are limited to a length which can be selected for each port.  The default value is 1024.  There is no such limit for outgoing sysex messages via RtMidiOut.
 
 RtMidi was originally developed with Visual C++ version 6.0 but has been tested with Virtual Studio 2010.
 


### PR DESCRIPTION
Hello.
The two first commits are only normalizing spaces and should be consensual.
The last one does what the title suggests.
SpotlightKid also suggests that the new function becomes a method only affecting the WinMM API and doing nothing on other APIs,
I do not mind the procedure as long as it is possible to set the buffer size at run time.
Thanks.