### PR TITLE
 Fix code formatting inconsistencies and remove trailing whitespace

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -178,7 +178,7 @@ class MidiOutAlsa: public MidiOutApi
   void openVirtualPort( const std::string &portName );
   void closePort( void );
   void setClientName( const std::string &clientName );
-  void setPortName( const std::string &portName);
+  void setPortName( const std::string &portName );
   unsigned int getPortCount( void );
   std::string getPortName( unsigned int portNumber );
   void sendMessage( const unsigned char *message, size_t size );
@@ -314,12 +314,12 @@ void RtMidi :: getCompiledApi( std::vector<RtMidi::Api> &apis ) throw()
 
 void RtMidi :: setClientName( const std::string &clientName )
 {
-  rtapi_->setClientName(clientName);
+  rtapi_->setClientName( clientName );
 }
 
 void RtMidi :: setPortName( const std::string &portName )
 {
-  rtapi_->setPortName(portName);
+  rtapi_->setPortName( portName );
 }
 
 
@@ -486,7 +486,7 @@ void MidiApi :: error( RtMidiError::Type type, std::string errorString )
     firstErrorOccurred_ = true;
     const std::string errorMessage = errorString;
 
-    errorCallback_( type, errorMessage, errorCallbackUserData_);
+    errorCallback_( type, errorMessage, errorCallbackUserData_ );
     firstErrorOccurred_ = false;
     return;
   }
@@ -575,38 +575,38 @@ double MidiInApi :: getMessage( std::vector<unsigned char> *message )
   }
 
   double timeStamp;
-  if (!inputData_.queue.pop(message, &timeStamp))
+  if ( !inputData_.queue.pop( message, &timeStamp ) )
     return 0.0;
 
   return timeStamp;
 }
 
-unsigned int MidiInApi::MidiQueue::size(unsigned int *__back,
-					unsigned int *__front)
+unsigned int MidiInApi::MidiQueue::size( unsigned int *__back,
+                                         unsigned int *__front )
 {
   // Access back/front members exactly once and make stack copies for
   // size calculation
   unsigned int _back = back, _front = front, _size;
-  if (_back >= _front)
+  if ( _back >= _front )
     _size = _back - _front;
   else
     _size = ringSize - _front + _back;
 
   // Return copies of back/front so no new and unsynchronized accesses
   // to member variables are needed.
-  if (__back) *__back = _back;
-  if (__front) *__front = _front;
+  if ( __back ) *__back = _back;
+  if ( __front ) *__front = _front;
   return _size;
 }
 
 // As long as we haven't reached our queue size limit, push the message.
-bool MidiInApi::MidiQueue::push(const MidiInApi::MidiMessage& msg)
+bool MidiInApi::MidiQueue::push( const MidiInApi::MidiMessage& msg )
 {
   // Local stack copies of front/back
   unsigned int _back, _front, _size;
 
   // Get back/front indexes exactly once and calculate current size
-  _size = size(&_back, &_front);
+  _size = size( &_back, &_front );
 
   if ( _size < ringSize-1 )
   {
@@ -618,15 +618,15 @@ bool MidiInApi::MidiQueue::push(const MidiInApi::MidiMessage& msg)
   return false;
 }
 
-bool MidiInApi::MidiQueue::pop(std::vector<unsigned char> *msg, double* timeStamp)
+bool MidiInApi::MidiQueue::pop( std::vector<unsigned char> *msg, double* timeStamp )
 {
   // Local stack copies of front/back
   unsigned int _back, _front, _size;
 
   // Get back/front indexes exactly once and calculate current size
-  _size = size(&_back, &_front);
+  _size = size( &_back, &_front );
 
-  if (_size == 0)
+  if ( _size == 0 )
     return false;
 
   // Copy queued message to the vector pointer argument and then "pop" it.
@@ -710,7 +710,7 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
 
     nBytes = packet->length;
     if ( nBytes == 0 ) {
-      packet = MIDIPacketNext(packet);
+      packet = MIDIPacketNext( packet );
       continue;
     }
 
@@ -752,7 +752,7 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
         }
         else {
           // As long as we haven't reached our queue size limit, push the message.
-          if (!data->queue.push(message))
+          if ( !data->queue.push( message ) )
             std::cerr << "\nMidiInCore: message queue limit reached!!\n\n";
         }
         message.bytes.clear();
@@ -778,12 +778,12 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
           continueSysex = packet->data[nBytes-1] != 0xF7;
         }
         else if ( status == 0xF1 ) {
-            // A MIDI time code message
-           if ( data->ignoreFlags & 0x02 ) {
+          // A MIDI time code message
+          if ( data->ignoreFlags & 0x02 ) {
             size = 0;
             iByte += 2;
-           }
-           else size = 2;
+          }
+          else size = 2;
         }
         else if ( status == 0xF2 ) size = 3;
         else if ( status == 0xF3 ) size = 2;
@@ -811,7 +811,7 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
             }
             else {
               // As long as we haven't reached our queue size limit, push the message.
-              if (!data->queue.push(message))
+              if ( !data->queue.push( message ) )
                 std::cerr << "\nMidiInCore: message queue limit reached!!\n\n";
             }
             message.bytes.clear();
@@ -822,8 +822,7 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
     }
 
     // Save the time of the last non-filtered message
-    if (foundNonFiltered)
-    {
+    if ( foundNonFiltered ) {
       apiData->lastTime = packet->timeStamp;
       if ( apiData->lastTime == 0 ) { // this happens when receiving asynchronous sysex messages
         apiData->lastTime = AudioGetCurrentHostTime();
@@ -834,7 +833,8 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
   }
 }
 
-MidiInCore :: MidiInCore( const std::string &clientName, unsigned int queueSizeLimit ) : MidiInApi( queueSizeLimit )
+MidiInCore :: MidiInCore( const std::string &clientName, unsigned int queueSizeLimit )
+  : MidiInApi( queueSizeLimit )
 {
   MidiInCore::initialize( clientName );
 }
@@ -871,7 +871,7 @@ void MidiInCore :: initialize( const std::string& clientName )
   data->endpoint = 0;
   apiData_ = (void *) data;
   inputData_.apiData = (void *) data;
-  CFRelease(name);
+  CFRelease( name );
 }
 
 void MidiInCore :: openPort( unsigned int portNumber, const std::string &portName )
@@ -884,7 +884,7 @@ void MidiInCore :: openPort( unsigned int portNumber, const std::string &portNam
 
   CFRunLoopRunInMode( kCFRunLoopDefaultMode, 0, false );
   unsigned int nSrc = MIDIGetNumberOfSources();
-  if (nSrc < 1) {
+  if ( nSrc < 1 ) {
     errorString_ = "MidiInCore::openPort: no MIDI input sources found!";
     error( RtMidiError::NO_DEVICES_FOUND, errorString_ );
     return;
@@ -901,11 +901,11 @@ void MidiInCore :: openPort( unsigned int portNumber, const std::string &portNam
   MIDIPortRef port;
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
   CFStringRef portNameRef = CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII );
-  OSStatus result = MIDIInputPortCreate( data->client, 
+  OSStatus result = MIDIInputPortCreate( data->client,
                                          portNameRef,
-                                         midiInputCallback, (void *)&inputData_, &port );                 
+                                         midiInputCallback, (void *)&inputData_, &port );
   CFRelease( portNameRef );
-  
+
   if ( result != noErr ) {
     MIDIClientDispose( data->client );
     errorString_ = "MidiInCore::openPort: error creating OS-X MIDI input port.";
@@ -950,7 +950,7 @@ void MidiInCore :: openVirtualPort( const std::string &portName )
                                            portNameRef,
                                            midiInputCallback, (void *)&inputData_, &endpoint );
   CFRelease( portNameRef );
-                                           
+
   if ( result != noErr ) {
     errorString_ = "MidiInCore::openVirtualPort: error creating virtual OS-X MIDI destination.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
@@ -1056,12 +1056,13 @@ CFStringRef EndpointName( MIDIEndpointRef endpoint, bool isExternal )
       // does the entity name already start with the device name?
       // (some drivers do this though they shouldn't)
       // if so, do not prepend
-        if ( CFStringCompareWithOptions( result, /* endpoint name */
-             str /* device name */,
-             CFRangeMake(0, CFStringGetLength( str ) ), 0 ) != kCFCompareEqualTo ) {
+      if ( CFStringCompareWithOptions( result, /* endpoint name */
+                                       str /* device name */,
+                                       CFRangeMake(0, CFStringGetLength( str ) ), 0 ) != kCFCompareEqualTo ) {
         // prepend the device name to the entity name
         if ( CFStringGetLength( result ) > 0 )
           CFStringInsert( result, 0, CFSTR(" ") );
+
         CFStringInsert( result, 0, str );
       }
       CFRelease( str );
@@ -1097,7 +1098,7 @@ static CFStringRef ConnectedEndpointName( MIDIEndpointRef endpoint )
         err = MIDIObjectFindByUniqueID( id, &connObject, &connObjectType );
         if ( err == noErr ) {
           if ( connObjectType == kMIDIObjectType_ExternalSource  ||
-              connObjectType == kMIDIObjectType_ExternalDestination ) {
+               connObjectType == kMIDIObjectType_ExternalDestination ) {
             // Connected to an external device's endpoint (10.3 and later).
             str = EndpointName( (MIDIEndpointRef)(connObject), true );
           } else {
@@ -1108,7 +1109,8 @@ static CFStringRef ConnectedEndpointName( MIDIEndpointRef endpoint )
           if ( str != NULL ) {
             if ( anyStrings )
               CFStringAppend( result, CFSTR(", ") );
-            else anyStrings = true;
+            else
+              anyStrings = true;
             CFStringAppend( result, str );
             CFRelease( str );
           }
@@ -1122,7 +1124,7 @@ static CFStringRef ConnectedEndpointName( MIDIEndpointRef endpoint )
 
   CFRelease( result );
 
-  // Here, either the endpoint had no connections, or we failed to obtain names 
+  // Here, either the endpoint had no connections, or we failed to obtain names
   return EndpointName( endpoint, false );
 }
 
@@ -1143,8 +1145,8 @@ std::string MidiInCore :: getPortName( unsigned int portNumber )
   }
 
   portRef = MIDIGetSource( portNumber );
-  nameRef = ConnectedEndpointName(portRef);
-  CFStringGetCString( nameRef, name, sizeof(name), kCFStringEncodingUTF8);
+  nameRef = ConnectedEndpointName( portRef );
+  CFStringGetCString( nameRef, name, sizeof(name), kCFStringEncodingUTF8 );
   CFRelease( nameRef );
 
   return stringName = name;
@@ -1155,7 +1157,8 @@ std::string MidiInCore :: getPortName( unsigned int portNumber )
 //  Class Definitions: MidiOutCore
 //*********************************************************************//
 
-MidiOutCore :: MidiOutCore( const std::string &clientName ) : MidiOutApi()
+MidiOutCore :: MidiOutCore( const std::string &clientName )
+  : MidiOutApi()
 {
   MidiOutCore::initialize( clientName );
 }
@@ -1220,7 +1223,7 @@ std::string MidiOutCore :: getPortName( unsigned int portNumber )
   nameRef = ConnectedEndpointName(portRef);
   CFStringGetCString( nameRef, name, sizeof(name), kCFStringEncodingUTF8 );
   CFRelease( nameRef );
-  
+
   return stringName = name;
 }
 
@@ -1251,9 +1254,7 @@ void MidiOutCore :: openPort( unsigned int portNumber, const std::string &portNa
   MIDIPortRef port;
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
   CFStringRef portNameRef = CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII );
-  OSStatus result = MIDIOutputPortCreate( data->client, 
-                                          portNameRef,
-                                          &port );
+  OSStatus result = MIDIOutputPortCreate( data->client, portNameRef, &port );
   CFRelease( portNameRef );
   if ( result != noErr ) {
     MIDIClientDispose( data->client );
@@ -1324,11 +1325,9 @@ void MidiOutCore :: openVirtualPort( const std::string &portName )
   // Create a virtual MIDI output source.
   MIDIEndpointRef endpoint;
   CFStringRef portNameRef = CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII );
-  OSStatus result = MIDISourceCreate( data->client,
-                                      portNameRef,
-                                      &endpoint );
+  OSStatus result = MIDISourceCreate( data->client, portNameRef, &endpoint );
   CFRelease( portNameRef );
-  
+
   if ( result != noErr ) {
     errorString_ = "MidiOutCore::initialize: error creating OS-X virtual MIDI source.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
@@ -1345,7 +1344,7 @@ void MidiOutCore :: sendMessage( const unsigned char *message, size_t size )
   // messages.  Otherwise, we use a single CoreMidi MIDIPacket.
   unsigned int nBytes = static_cast<unsigned int> (size);
   if ( nBytes == 0 ) {
-    errorString_ = "MidiOutCore::sendMessage: no data in message argument!";      
+    errorString_ = "MidiOutCore::sendMessage: no data in message argument!";
     error( RtMidiError::WARNING, errorString_ );
     return;
   }
@@ -1360,21 +1359,21 @@ void MidiOutCore :: sendMessage( const unsigned char *message, size_t size )
     return;
   }
 
-  Byte buffer[nBytes+(sizeof(MIDIPacketList))];
-  ByteCount listSize = sizeof(buffer);
+  Byte buffer[nBytes+(sizeof( MIDIPacketList ))];
+  ByteCount listSize = sizeof( buffer );
   MIDIPacketList *packetList = (MIDIPacketList*)buffer;
   MIDIPacket *packet = MIDIPacketListInit( packetList );
 
   ByteCount remainingBytes = nBytes;
-  while (remainingBytes && packet) {
+  while ( remainingBytes && packet ) {
     ByteCount bytesForPacket = remainingBytes > 65535 ? 65535 : remainingBytes; // 65535 = maximum size of a MIDIPacket
     const Byte* dataStartPtr = (const Byte *) &message[nBytes - remainingBytes];
-    packet = MIDIPacketListAdd( packetList, listSize, packet, timeStamp, bytesForPacket, dataStartPtr);
-    remainingBytes -= bytesForPacket; 
+    packet = MIDIPacketListAdd( packetList, listSize, packet, timeStamp, bytesForPacket, dataStartPtr );
+    remainingBytes -= bytesForPacket;
   }
 
   if ( !packet ) {
-    errorString_ = "MidiOutCore::sendMessage: could not allocate packet list";      
+    errorString_ = "MidiOutCore::sendMessage: could not allocate packet list";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
   }
@@ -1555,7 +1554,7 @@ static void *alsaMidiHandler( void *ptr )
       if ( !( data->ignoreFlags & 0x04 ) ) doDecode = true;
       break;
 
-		case SND_SEQ_EVENT_SYSEX:
+    case SND_SEQ_EVENT_SYSEX:
       if ( (data->ignoreFlags & 0x01) ) break;
       if ( ev->data.ext.len > apiData->bufferSize ) {
         apiData->bufferSize = ev->data.ext.len;
@@ -1606,16 +1605,16 @@ static void *alsaMidiHandler( void *ptr )
           // Perform the carry for the later subtraction by updating y.
           // Temp var y is timespec because computation requires signed types,
           // while snd_seq_real_time_t has unsigned types.
-          snd_seq_real_time_t &x(ev->time.time);
+          snd_seq_real_time_t &x( ev->time.time );
           struct timespec y;
           y.tv_nsec = apiData->lastTime.tv_nsec;
           y.tv_sec = apiData->lastTime.tv_sec;
-          if (x.tv_nsec < y.tv_nsec) {
+          if ( x.tv_nsec < y.tv_nsec ) {
               int nsec = (y.tv_nsec - (int)x.tv_nsec) / 1000000000 + 1;
               y.tv_nsec -= 1000000000 * nsec;
               y.tv_sec += nsec;
           }
-          if (x.tv_nsec - y.tv_nsec > 1000000000) {
+          if ( x.tv_nsec - y.tv_nsec > 1000000000 ) {
               int nsec = ((int)x.tv_nsec - y.tv_nsec) / 1000000000;
               y.tv_nsec += 1000000000 * nsec;
               y.tv_sec -= nsec;
@@ -1648,7 +1647,7 @@ static void *alsaMidiHandler( void *ptr )
     }
     else {
       // As long as we haven't reached our queue size limit, push the message.
-      if (!data->queue.push(message))
+      if ( !data->queue.push( message ) )
         std::cerr << "\nMidiInAlsa: message queue limit reached!!\n\n";
     }
   }
@@ -1660,7 +1659,8 @@ static void *alsaMidiHandler( void *ptr )
   return 0;
 }
 
-MidiInAlsa :: MidiInAlsa( const std::string &clientName, unsigned int queueSizeLimit ) : MidiInApi( queueSizeLimit )
+MidiInAlsa :: MidiInAlsa( const std::string &clientName, unsigned int queueSizeLimit )
+  : MidiInApi( queueSizeLimit )
 {
   MidiInAlsa::initialize( clientName );
 }
@@ -1674,7 +1674,7 @@ MidiInAlsa :: ~MidiInAlsa()
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( inputData_.doInput ) {
     inputData_.doInput = false;
-    int res = write( data->trigger_fds[1], &inputData_.doInput, sizeof(inputData_.doInput) );
+    int res = write( data->trigger_fds[1], &inputData_.doInput, sizeof( inputData_.doInput ) );
     (void) res;
     if ( !pthread_equal(data->thread, data->dummy_thread_id) )
       pthread_join( data->thread, NULL );
@@ -1695,7 +1695,7 @@ void MidiInAlsa :: initialize( const std::string& clientName )
 {
   // Set up the ALSA sequencer client.
   snd_seq_t *seq;
-  int result = snd_seq_open(&seq, "default", SND_SEQ_OPEN_DUPLEX, SND_SEQ_NONBLOCK);
+  int result = snd_seq_open( &seq, "default", SND_SEQ_OPEN_DUPLEX, SND_SEQ_NONBLOCK );
   if ( result < 0 ) {
     errorString_ = "MidiInAlsa::initialize: error creating ALSA sequencer client object.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
@@ -1718,7 +1718,7 @@ void MidiInAlsa :: initialize( const std::string& clientName )
   apiData_ = (void *) data;
   inputData_.apiData = (void *) data;
 
-   if ( pipe(data->trigger_fds) == -1 ) {
+  if ( pipe(data->trigger_fds) == -1 ) {
     errorString_ = "MidiInAlsa::initialize: error creating pipe objects.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
@@ -1726,14 +1726,14 @@ void MidiInAlsa :: initialize( const std::string& clientName )
 
   // Create the input queue
 #ifndef AVOID_TIMESTAMPING
-  data->queue_id = snd_seq_alloc_named_queue(seq, "RtMidi Queue");
+  data->queue_id = snd_seq_alloc_named_queue( seq, "RtMidi Queue" );
   // Set arbitrary tempo (mm=100) and resolution (240)
   snd_seq_queue_tempo_t *qtempo;
-  snd_seq_queue_tempo_alloca(&qtempo);
-  snd_seq_queue_tempo_set_tempo(qtempo, 600000);
-  snd_seq_queue_tempo_set_ppq(qtempo, 240);
-  snd_seq_set_queue_tempo(data->seq, data->queue_id, qtempo);
-  snd_seq_drain_output(data->seq);
+  snd_seq_queue_tempo_alloca( &qtempo );
+  snd_seq_queue_tempo_set_tempo( qtempo, 600000 );
+  snd_seq_queue_tempo_set_ppq( qtempo, 240 );
+  snd_seq_set_queue_tempo( data->seq, data->queue_id, qtempo );
+  snd_seq_drain_output( data->seq );
 #endif
 }
 
@@ -1757,7 +1757,7 @@ unsigned int portInfo( snd_seq_t *seq, snd_seq_port_info_t *pinfo, unsigned int 
       if ( ( ( atyp & SND_SEQ_PORT_TYPE_MIDI_GENERIC ) == 0 ) &&
            ( ( atyp & SND_SEQ_PORT_TYPE_SYNTH ) == 0 ) &&
            ( ( atyp & SND_SEQ_PORT_TYPE_APPLICATION ) == 0 ) ) continue;
-	    
+
       unsigned int caps = snd_seq_port_info_get_capability( pinfo );
       if ( ( caps & type ) != type ) continue;
       if ( count == portNumber ) return 1;
@@ -1853,33 +1853,33 @@ void MidiInAlsa :: openPort( unsigned int portNumber, const std::string &portNam
                                 SND_SEQ_PORT_TYPE_APPLICATION );
     snd_seq_port_info_set_midi_channels(pinfo, 16);
 #ifndef AVOID_TIMESTAMPING
-    snd_seq_port_info_set_timestamping(pinfo, 1);
-    snd_seq_port_info_set_timestamp_real(pinfo, 1);    
-    snd_seq_port_info_set_timestamp_queue(pinfo, data->queue_id);
+    snd_seq_port_info_set_timestamping( pinfo, 1 );
+    snd_seq_port_info_set_timestamp_real( pinfo, 1 );
+    snd_seq_port_info_set_timestamp_queue( pinfo, data->queue_id );
 #endif
-    snd_seq_port_info_set_name(pinfo,  portName.c_str() );
-    data->vport = snd_seq_create_port(data->seq, pinfo);
-  
+    snd_seq_port_info_set_name( pinfo,  portName.c_str() );
+    data->vport = snd_seq_create_port( data->seq, pinfo );
+
     if ( data->vport < 0 ) {
       errorString_ = "MidiInAlsa::openPort: ALSA error creating input port.";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
     }
-    data->vport = snd_seq_port_info_get_port(pinfo);
+    data->vport = snd_seq_port_info_get_port( pinfo );
   }
 
   receiver.port = data->vport;
 
   if ( !data->subscription ) {
     // Make subscription
-    if (snd_seq_port_subscribe_malloc( &data->subscription ) < 0) {
+    if ( snd_seq_port_subscribe_malloc( &data->subscription ) < 0 ) {
       errorString_ = "MidiInAlsa::openPort: ALSA error allocation port subscription.";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
     }
-    snd_seq_port_subscribe_set_sender(data->subscription, &sender);
-    snd_seq_port_subscribe_set_dest(data->subscription, &receiver);
-    if ( snd_seq_subscribe_port(data->seq, data->subscription) ) {
+    snd_seq_port_subscribe_set_sender( data->subscription, &sender );
+    snd_seq_port_subscribe_set_dest( data->subscription, &receiver );
+    if ( snd_seq_subscribe_port( data->seq, data->subscription ) ) {
       snd_seq_port_subscribe_free( data->subscription );
       data->subscription = 0;
       errorString_ = "MidiInAlsa::openPort: ALSA error making port connection.";
@@ -1896,13 +1896,13 @@ void MidiInAlsa :: openPort( unsigned int portNumber, const std::string &portNam
 #endif
     // Start our MIDI input thread.
     pthread_attr_t attr;
-    pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-    pthread_attr_setschedpolicy(&attr, SCHED_OTHER);
+    pthread_attr_init( &attr );
+    pthread_attr_setdetachstate( &attr, PTHREAD_CREATE_JOINABLE );
+    pthread_attr_setschedpolicy( &attr, SCHED_OTHER );
 
     inputData_.doInput = true;
-    int err = pthread_create(&data->thread, &attr, alsaMidiHandler, &inputData_);
-    pthread_attr_destroy(&attr);
+    int err = pthread_create( &data->thread, &attr, alsaMidiHandler, &inputData_ );
+    pthread_attr_destroy( &attr );
     if ( err ) {
       snd_seq_unsubscribe_port( data->seq, data->subscription );
       snd_seq_port_subscribe_free( data->subscription );
@@ -1924,31 +1924,31 @@ void MidiInAlsa :: openVirtualPort( const std::string &portName )
     snd_seq_port_info_t *pinfo;
     snd_seq_port_info_alloca( &pinfo );
     snd_seq_port_info_set_capability( pinfo,
-				      SND_SEQ_PORT_CAP_WRITE |
-				      SND_SEQ_PORT_CAP_SUBS_WRITE );
+                                      SND_SEQ_PORT_CAP_WRITE |
+                                      SND_SEQ_PORT_CAP_SUBS_WRITE );
     snd_seq_port_info_set_type( pinfo,
-				SND_SEQ_PORT_TYPE_MIDI_GENERIC |
-				SND_SEQ_PORT_TYPE_APPLICATION );
-    snd_seq_port_info_set_midi_channels(pinfo, 16);
+                                SND_SEQ_PORT_TYPE_MIDI_GENERIC |
+                                SND_SEQ_PORT_TYPE_APPLICATION );
+    snd_seq_port_info_set_midi_channels( pinfo, 16 );
 #ifndef AVOID_TIMESTAMPING
-    snd_seq_port_info_set_timestamping(pinfo, 1);
-    snd_seq_port_info_set_timestamp_real(pinfo, 1);    
-    snd_seq_port_info_set_timestamp_queue(pinfo, data->queue_id);
+    snd_seq_port_info_set_timestamping( pinfo, 1 );
+    snd_seq_port_info_set_timestamp_real( pinfo, 1 );
+    snd_seq_port_info_set_timestamp_queue( pinfo, data->queue_id );
 #endif
-    snd_seq_port_info_set_name(pinfo, portName.c_str());
-    data->vport = snd_seq_create_port(data->seq, pinfo);
+    snd_seq_port_info_set_name( pinfo, portName.c_str() );
+    data->vport = snd_seq_create_port( data->seq, pinfo );
 
     if ( data->vport < 0 ) {
       errorString_ = "MidiInAlsa::openVirtualPort: ALSA error creating virtual port.";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
     }
-    data->vport = snd_seq_port_info_get_port(pinfo);
+    data->vport = snd_seq_port_info_get_port( pinfo );
   }
 
   if ( inputData_.doInput == false ) {
     // Wait for old thread to stop, if still running
-    if ( !pthread_equal(data->thread, data->dummy_thread_id) )
+    if ( !pthread_equal( data->thread, data->dummy_thread_id ) )
       pthread_join( data->thread, NULL );
 
     // Start the input queue
@@ -1958,13 +1958,13 @@ void MidiInAlsa :: openVirtualPort( const std::string &portName )
 #endif
     // Start our MIDI input thread.
     pthread_attr_t attr;
-    pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-    pthread_attr_setschedpolicy(&attr, SCHED_OTHER);
+    pthread_attr_init( &attr );
+    pthread_attr_setdetachstate( &attr, PTHREAD_CREATE_JOINABLE );
+    pthread_attr_setschedpolicy( &attr, SCHED_OTHER );
 
     inputData_.doInput = true;
-    int err = pthread_create(&data->thread, &attr, alsaMidiHandler, &inputData_);
-    pthread_attr_destroy(&attr);
+    int err = pthread_create( &data->thread, &attr, alsaMidiHandler, &inputData_ );
+    pthread_attr_destroy( &attr );
     if ( err ) {
       if ( data->subscription ) {
         snd_seq_unsubscribe_port( data->seq, data->subscription );
@@ -2000,9 +2000,9 @@ void MidiInAlsa :: closePort( void )
   // Stop thread to avoid triggering the callback, while the port is intended to be closed
   if ( inputData_.doInput ) {
     inputData_.doInput = false;
-    int res = write( data->trigger_fds[1], &inputData_.doInput, sizeof(inputData_.doInput) );
+    int res = write( data->trigger_fds[1], &inputData_.doInput, sizeof( inputData_.doInput ) );
     (void) res;
-    if ( !pthread_equal(data->thread, data->dummy_thread_id) )
+    if ( !pthread_equal( data->thread, data->dummy_thread_id ) )
       pthread_join( data->thread, NULL );
   }
 }
@@ -2010,8 +2010,8 @@ void MidiInAlsa :: closePort( void )
 void MidiInAlsa :: setClientName( const std::string &clientName )
 {
 
-    AlsaMidiData *data = static_cast<AlsaMidiData *> ( apiData_ );
-    snd_seq_set_client_name( data->seq, clientName.c_str() );
+  AlsaMidiData *data = static_cast<AlsaMidiData *> ( apiData_ );
+  snd_seq_set_client_name( data->seq, clientName.c_str() );
 
 }
 
@@ -2058,7 +2058,7 @@ void MidiOutAlsa :: initialize( const std::string& clientName )
     errorString_ = "MidiOutAlsa::initialize: error creating ALSA sequencer client object.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
-	}
+  }
 
   // Set client name.
   snd_seq_set_client_name( seq, clientName.c_str() );
@@ -2091,8 +2091,8 @@ void MidiOutAlsa :: initialize( const std::string& clientName )
 
 unsigned int MidiOutAlsa :: getPortCount()
 {
-	snd_seq_port_info_t *pinfo;
-	snd_seq_port_info_alloca( &pinfo );
+  snd_seq_port_info_t *pinfo;
+  snd_seq_port_info_alloca( &pinfo );
 
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   return portInfo( data->seq, pinfo, SND_SEQ_PORT_CAP_WRITE|SND_SEQ_PORT_CAP_SUBS_WRITE, -1 );
@@ -2108,16 +2108,16 @@ std::string MidiOutAlsa :: getPortName( unsigned int portNumber )
   std::string stringName;
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( portInfo( data->seq, pinfo, SND_SEQ_PORT_CAP_WRITE|SND_SEQ_PORT_CAP_SUBS_WRITE, (int) portNumber ) ) {
-    int cnum = snd_seq_port_info_get_client(pinfo);
+    int cnum = snd_seq_port_info_get_client( pinfo );
     snd_seq_get_any_client_info( data->seq, cnum, cinfo );
     std::ostringstream os;
-    os << snd_seq_client_info_get_name(cinfo);
+    os << snd_seq_client_info_get_name( cinfo );
     os << ":";
     os << snd_seq_port_info_get_name( pinfo );
     os << " ";                                    // These lines added to make sure devices are listed
     os << snd_seq_port_info_get_client( pinfo );  // with full portnames added to ensure individual device names
     os << ":";
-    os << snd_seq_port_info_get_port(pinfo);
+    os << snd_seq_port_info_get_port( pinfo );
     stringName = os.str();
     return stringName;
   }
@@ -2137,14 +2137,14 @@ void MidiOutAlsa :: openPort( unsigned int portNumber, const std::string &portNa
   }
 
   unsigned int nSrc = this->getPortCount();
-  if (nSrc < 1) {
+  if ( nSrc < 1 ) {
     errorString_ = "MidiOutAlsa::openPort: no MIDI output sources found!";
     error( RtMidiError::NO_DEVICES_FOUND, errorString_ );
     return;
   }
 
-	snd_seq_port_info_t *pinfo;
-	snd_seq_port_info_alloca( &pinfo );
+  snd_seq_port_info_t *pinfo;
+  snd_seq_port_info_alloca( &pinfo );
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( portInfo( data->seq, pinfo, SND_SEQ_PORT_CAP_WRITE|SND_SEQ_PORT_CAP_SUBS_WRITE, (int) portNumber ) == 0 ) {
     std::ostringstream ost;
@@ -2173,17 +2173,17 @@ void MidiOutAlsa :: openPort( unsigned int portNumber, const std::string &portNa
   sender.port = data->vport;
 
   // Make subscription
-  if (snd_seq_port_subscribe_malloc( &data->subscription ) < 0) {
+  if ( snd_seq_port_subscribe_malloc( &data->subscription ) < 0 ) {
     snd_seq_port_subscribe_free( data->subscription );
     errorString_ = "MidiOutAlsa::openPort: error allocating port subscription.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
   }
-  snd_seq_port_subscribe_set_sender(data->subscription, &sender);
-  snd_seq_port_subscribe_set_dest(data->subscription, &receiver);
-  snd_seq_port_subscribe_set_time_update(data->subscription, 1);
-  snd_seq_port_subscribe_set_time_real(data->subscription, 1);
-  if ( snd_seq_subscribe_port(data->seq, data->subscription) ) {
+  snd_seq_port_subscribe_set_sender( data->subscription, &sender );
+  snd_seq_port_subscribe_set_dest( data->subscription, &receiver );
+  snd_seq_port_subscribe_set_time_update( data->subscription, 1 );
+  snd_seq_port_subscribe_set_time_real( data->subscription, 1 );
+  if ( snd_seq_subscribe_port( data->seq, data->subscription ) ) {
     snd_seq_port_subscribe_free( data->subscription );
     errorString_ = "MidiOutAlsa::openPort: ALSA error making port connection.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
@@ -2244,7 +2244,7 @@ void MidiOutAlsa :: sendMessage( const unsigned char *message, size_t size )
   unsigned int nBytes = static_cast<unsigned int> (size);
   if ( nBytes > data->bufferSize ) {
     data->bufferSize = nBytes;
-    result = snd_midi_event_resize_buffer ( data->coder, nBytes);
+    result = snd_midi_event_resize_buffer( data->coder, nBytes );
     if ( result != 0 ) {
       errorString_ = "MidiOutAlsa::sendMessage: ALSA error resizing MIDI event buffer.";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
@@ -2253,17 +2253,17 @@ void MidiOutAlsa :: sendMessage( const unsigned char *message, size_t size )
     free (data->buffer);
     data->buffer = (unsigned char *) malloc( data->bufferSize );
     if ( data->buffer == NULL ) {
-    errorString_ = "MidiOutAlsa::initialize: error allocating buffer memory!\n\n";
-    error( RtMidiError::MEMORY_ERROR, errorString_ );
-    return;
+      errorString_ = "MidiOutAlsa::initialize: error allocating buffer memory!\n\n";
+      error( RtMidiError::MEMORY_ERROR, errorString_ );
+      return;
     }
   }
 
   snd_seq_event_t ev;
-  snd_seq_ev_clear(&ev);
-  snd_seq_ev_set_source(&ev, data->vport);
-  snd_seq_ev_set_subs(&ev);
-  snd_seq_ev_set_direct(&ev);
+  snd_seq_ev_clear( &ev );
+  snd_seq_ev_set_source( &ev, data->vport );
+  snd_seq_ev_set_subs( &ev );
+  snd_seq_ev_set_direct( &ev );
   for ( unsigned int i=0; i<nBytes; ++i ) data->buffer[i] = message[i];
   result = snd_midi_event_encode( data->coder, data->buffer, (long)nBytes, &ev );
   if ( result < (int)nBytes ) {
@@ -2273,13 +2273,13 @@ void MidiOutAlsa :: sendMessage( const unsigned char *message, size_t size )
   }
 
   // Send the event.
-  result = snd_seq_event_output(data->seq, &ev);
+  result = snd_seq_event_output( data->seq, &ev );
   if ( result < 0 ) {
     errorString_ = "MidiOutAlsa::sendMessage: error sending MIDI message to port.";
     error( RtMidiError::WARNING, errorString_ );
     return;
   }
-  snd_seq_drain_output(data->seq);
+  snd_seq_drain_output( data->seq );
 }
 
 #endif // __LINUX_ALSA__
@@ -2352,7 +2352,7 @@ struct WinMidiData {
 //*********************************************************************//
 
 static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
-                                        UINT inputStatus, 
+                                        UINT inputStatus,
                                         DWORD_PTR instancePtr,
                                         DWORD_PTR midiMessage,
                                         DWORD timestamp )
@@ -2387,11 +2387,11 @@ static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
     }
     else if ( status == 0xF2 ) nBytes = 3;
     else if ( status == 0xF3 ) nBytes = 2;
-    else if ( status == 0xF8 && (data->ignoreFlags & 0x02) ) {
+    else if ( status == 0xF8 && ( data->ignoreFlags & 0x02 ) ) {
       // A MIDI timing tick message and we're ignoring it.
       return;
     }
-    else if ( status == 0xFE && (data->ignoreFlags & 0x04) ) {
+    else if ( status == 0xFE && ( data->ignoreFlags & 0x04 ) ) {
       // A MIDI active sensing message and we're ignoring it.
       return;
     }
@@ -2401,8 +2401,8 @@ static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
     for ( int i=0; i<nBytes; ++i ) apiData->message.bytes.push_back( *ptr++ );
   }
   else { // Sysex message ( MIM_LONGDATA or MIM_LONGERROR )
-    MIDIHDR *sysex = ( MIDIHDR *) midiMessage; 
-    if ( !( data->ignoreFlags & 0x01 ) && inputStatus != MIM_LONGERROR ) {  
+    MIDIHDR *sysex = ( MIDIHDR *) midiMessage;
+    if ( !( data->ignoreFlags & 0x01 ) && inputStatus != MIM_LONGERROR ) {
       // Sysex message and we're not ignoring it
       for ( int i=0; i<(int)sysex->dwBytesRecorded; ++i )
         apiData->message.bytes.push_back( sysex->lpData[i] );
@@ -2438,7 +2438,7 @@ static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
   }
   else {
     // As long as we haven't reached our queue size limit, push the message.
-    if (!data->queue.push(apiData->message))
+    if ( !data->queue.push( apiData->message ) )
       std::cerr << "\nMidiInWinMM: message queue limit reached!!\n\n";
   }
 
@@ -2446,7 +2446,8 @@ static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
   apiData->message.bytes.clear();
 }
 
-MidiInWinMM :: MidiInWinMM( const std::string &clientName, unsigned int queueSizeLimit ) : MidiInApi( queueSizeLimit )
+MidiInWinMM :: MidiInWinMM( const std::string &clientName, unsigned int queueSizeLimit )
+  : MidiInApi( queueSizeLimit )
 {
   MidiInWinMM::initialize( clientName );
 }
@@ -2479,7 +2480,7 @@ void MidiInWinMM :: initialize( const std::string& /*clientName*/ )
   inputData_.apiData = (void *) data;
   data->message.bytes.clear();  // needs to be empty for first input message
 
-  if ( !InitializeCriticalSectionAndSpinCount(&(data->_mutex), 0x00000400) ) {
+  if ( !InitializeCriticalSectionAndSpinCount( &(data->_mutex), 0x00000400 ) ) {
     errorString_ = "MidiInWinMM::initialize: InitializeCriticalSectionAndSpinCount failed.";
     error( RtMidiError::WARNING, errorString_ );
   }
@@ -2632,7 +2633,7 @@ std::string MidiInWinMM :: getPortName( unsigned int portNumber )
   midiInGetDevCaps( portNumber, &deviceCaps, sizeof(MIDIINCAPS));
   stringName = ConvertToUTF8( deviceCaps.szPname );
 
-  // Next lines added to add the portNumber to the name so that 
+  // Next lines added to add the portNumber to the name so that
   // the device's names are sure to be listed with individual names
   // even when they have the same brand name
 #ifndef RTMIDI_DO_NOT_ENSURE_UNIQUE_PORTNAMES
@@ -2698,10 +2699,10 @@ std::string MidiOutWinMM :: getPortName( unsigned int portNumber )
   }
 
   MIDIOUTCAPS deviceCaps;
-  midiOutGetDevCaps( portNumber, &deviceCaps, sizeof(MIDIOUTCAPS));
+  midiOutGetDevCaps( portNumber, &deviceCaps, sizeof( MIDIOUTCAPS ) );
   stringName = ConvertToUTF8( deviceCaps.szPname );
 
-  // Next lines added to add the portNumber to the name so that 
+  // Next lines added to add the portNumber to the name so that
   // the device's names are sure to be listed with individual names
   // even when they have the same brand name
   std::ostringstream os;
@@ -2723,7 +2724,7 @@ void MidiOutWinMM :: openPort( unsigned int portNumber, const std::string &/*por
   }
 
   unsigned int nDevices = midiOutGetNumDevs();
-  if (nDevices < 1) {
+  if ( nDevices < 1 ) {
     errorString_ = "MidiOutWinMM::openPort: no MIDI output destinations found!";
     error( RtMidiError::NO_DEVICES_FOUND, errorString_ );
     return;
@@ -2817,7 +2818,7 @@ void MidiOutWinMM :: sendMessage( const unsigned char *message, size_t size )
     sysex.lpData = (LPSTR) buffer;
     sysex.dwBufferLength = nBytes;
     sysex.dwFlags = 0;
-    result = midiOutPrepareHeader( data->outHandle,  &sysex, sizeof(MIDIHDR) ); 
+    result = midiOutPrepareHeader( data->outHandle,  &sysex, sizeof( MIDIHDR ) );
     if ( result != MMSYSERR_NOERROR ) {
       free( buffer );
       errorString_ = "MidiOutWinMM::sendMessage: error preparing sysex header.";
@@ -2826,7 +2827,7 @@ void MidiOutWinMM :: sendMessage( const unsigned char *message, size_t size )
     }
 
     // Send the message.
-    result = midiOutLongMsg( data->outHandle, &sysex, sizeof(MIDIHDR) );
+    result = midiOutLongMsg( data->outHandle, &sysex, sizeof( MIDIHDR ) );
     if ( result != MMSYSERR_NOERROR ) {
       free( buffer );
       errorString_ = "MidiOutWinMM::sendMessage: error sending sysex message.";
@@ -2835,7 +2836,7 @@ void MidiOutWinMM :: sendMessage( const unsigned char *message, size_t size )
     }
 
     // Unprepare the buffer and MIDIHDR.
-    while ( MIDIERR_STILLPLAYING == midiOutUnprepareHeader( data->outHandle, &sysex, sizeof (MIDIHDR) ) ) Sleep( 1 );
+    while ( MIDIERR_STILLPLAYING == midiOutUnprepareHeader( data->outHandle, &sysex, sizeof ( MIDIHDR ) ) ) Sleep( 1 );
     free( buffer );
   }
   else { // Channel or system message.
@@ -2943,7 +2944,7 @@ static int jackProcessIn( jack_nframes_t nframes, void *arg )
       }
       else {
         // As long as we haven't reached our queue size limit, push the message.
-        if (!rtData->queue.push(message))
+        if ( !rtData->queue.push( message ) )
           std::cerr << "\nMidiInJack: message queue limit reached!!\n\n";
       }
     }
@@ -2952,7 +2953,8 @@ static int jackProcessIn( jack_nframes_t nframes, void *arg )
   return 0;
 }
 
-MidiInJack :: MidiInJack( const std::string &clientName, unsigned int queueSizeLimit ) : MidiInApi( queueSizeLimit )
+MidiInJack :: MidiInJack( const std::string &clientName, unsigned int queueSizeLimit )
+  : MidiInApi( queueSizeLimit )
 {
   MidiInJack::initialize( clientName );
 }
@@ -3004,11 +3006,11 @@ void MidiInJack :: openPort( unsigned int portNumber, const std::string &portNam
   connect();
 
   // Creating new port
-  if ( data->port == NULL)
+  if ( data->port == NULL )
     data->port = jack_port_register( data->client, portName.c_str(),
                                      JACK_DEFAULT_MIDI_TYPE, JackPortIsInput, 0 );
 
-  if ( data->port == NULL) {
+  if ( data->port == NULL ) {
     errorString_ = "MidiInJack::openPort: JACK error creating port";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
@@ -3057,7 +3059,7 @@ unsigned int MidiInJack :: getPortCount()
 std::string MidiInJack :: getPortName( unsigned int portNumber )
 {
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
-  std::string retStr("");
+  std::string retStr( "" );
 
   connect();
 
@@ -3073,8 +3075,8 @@ std::string MidiInJack :: getPortName( unsigned int portNumber )
   }
 
   unsigned int i;
-  for (i=0; i<portNumber && ports[i]; i++) {}
-  if (i < portNumber || !ports[portNumber]) {
+  for ( i=0; i<portNumber && ports[i]; i++ ) {}
+  if ( i < portNumber || !ports[portNumber] ) {
     std::ostringstream ost;
     ost << "MidiInJack::getPortName: the 'portNumber' argument (" << portNumber << ") is invalid.";
     errorString_ = ost.str();
@@ -3132,15 +3134,15 @@ static int jackProcessOut( jack_nframes_t nframes, void *arg )
   jack_midi_clear_buffer( buff );
 
   while ( jack_ringbuffer_read_space( data->buffSize ) > 0 ) {
-    jack_ringbuffer_read( data->buffSize, (char *) &space, (size_t) sizeof(space) );
+    jack_ringbuffer_read( data->buffSize, (char *) &space, (size_t) sizeof( space ) );
     midiData = jack_midi_event_reserve( buff, 0, space );
 
     jack_ringbuffer_read( data->buffMessage, (char *) midiData, (size_t) space );
   }
 
 #ifdef HAVE_SEMAPHORE
-  if (!sem_trywait(&data->sem_needpost))
-    sem_post(&data->sem_cleanup);
+  if ( !sem_trywait( &data->sem_needpost ) )
+    sem_post( &data->sem_cleanup );
 #endif
 
   return 0;
@@ -3159,8 +3161,8 @@ void MidiOutJack :: initialize( const std::string& clientName )
   data->port = NULL;
   data->client = NULL;
 #ifdef HAVE_SEMAPHORE
-  sem_init(&data->sem_cleanup, 0, 0);
-  sem_init(&data->sem_needpost, 0, 0);
+  sem_init( &data->sem_cleanup, 0, 0 );
+  sem_init( &data->sem_needpost, 0, 0 );
 #endif
   this->clientName = clientName;
 
@@ -3172,13 +3174,13 @@ void MidiOutJack :: connect()
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
   if ( data->client )
     return;
-  
-  // Initialize output ringbuffers  
+
+  // Initialize output ringbuffers
   data->buffSize = jack_ringbuffer_create( JACK_RINGBUFFER_SIZE );
   data->buffMessage = jack_ringbuffer_create( JACK_RINGBUFFER_SIZE );
 
   // Initialize JACK client
-  if (( data->client = jack_client_open( clientName.c_str(), JackNoStartServer, NULL )) == 0) {
+  if ( ( data->client = jack_client_open( clientName.c_str(), JackNoStartServer, NULL ) ) == 0 ) {
     errorString_ = "MidiOutJack::initialize: JACK server not running?";
     error( RtMidiError::WARNING, errorString_ );
     return;
@@ -3201,8 +3203,8 @@ MidiOutJack :: ~MidiOutJack()
   }
 
 #ifdef HAVE_SEMAPHORE
-  sem_destroy(&data->sem_cleanup);
-  sem_destroy(&data->sem_needpost);
+  sem_destroy( &data->sem_cleanup );
+  sem_destroy( &data->sem_needpost );
 #endif
 
   delete data;
@@ -3217,7 +3219,7 @@ void MidiOutJack :: openPort( unsigned int portNumber, const std::string &portNa
   // Creating new port
   if ( data->port == NULL )
     data->port = jack_port_register( data->client, portName.c_str(),
-      JACK_DEFAULT_MIDI_TYPE, JackPortIsOutput, 0 );
+                                     JACK_DEFAULT_MIDI_TYPE, JackPortIsOutput, 0 );
 
   if ( data->port == NULL ) {
     errorString_ = "MidiOutJack::openPort: JACK error creating port";
@@ -3237,7 +3239,7 @@ void MidiOutJack :: openVirtualPort( const std::string &portName )
   connect();
   if ( data->port == NULL )
     data->port = jack_port_register( data->client, portName.c_str(),
-      JACK_DEFAULT_MIDI_TYPE, JackPortIsOutput, 0 );
+                                     JACK_DEFAULT_MIDI_TYPE, JackPortIsOutput, 0 );
 
   if ( data->port == NULL ) {
     errorString_ = "MidiOutJack::openVirtualPort: JACK error creating virtual port";
@@ -3255,7 +3257,7 @@ unsigned int MidiOutJack :: getPortCount()
 
   // List of available ports
   const char **ports = jack_get_ports( data->client, NULL,
-    JACK_DEFAULT_MIDI_TYPE, JackPortIsInput );
+                                       JACK_DEFAULT_MIDI_TYPE, JackPortIsInput );
 
   if ( ports == NULL ) return 0;
   while ( ports[count] != NULL )
@@ -3275,16 +3277,16 @@ std::string MidiOutJack :: getPortName( unsigned int portNumber )
 
   // List of available ports
   const char **ports = jack_get_ports( data->client, NULL,
-    JACK_DEFAULT_MIDI_TYPE, JackPortIsInput );
+                                       JACK_DEFAULT_MIDI_TYPE, JackPortIsInput );
 
   // Check port validity
-  if ( ports == NULL) {
+  if ( ports == NULL ) {
     errorString_ = "MidiOutJack::getPortName: no ports available!";
     error( RtMidiError::WARNING, errorString_ );
     return retStr;
   }
 
-  if ( ports[portNumber] == NULL) {
+  if ( ports[portNumber] == NULL ) {
     std::ostringstream ost;
     ost << "MidiOutJack::getPortName: the 'portNumber' argument (" << portNumber << ") is invalid.";
     errorString_ = ost.str();
@@ -3304,11 +3306,10 @@ void MidiOutJack :: closePort()
 
 #ifdef HAVE_SEMAPHORE
   struct timespec ts;
-  if (clock_gettime(CLOCK_REALTIME, &ts) != -1)
-  {
+  if ( clock_gettime( CLOCK_REALTIME, &ts ) != -1 ) {
     ts.tv_sec += 1; // wait max one second
-    sem_post(&data->sem_needpost);
-    sem_timedwait(&data->sem_cleanup, &ts);
+    sem_post( &data->sem_needpost );
+    sem_timedwait( &data->sem_cleanup, &ts );
   }
 #endif
 
@@ -3340,8 +3341,7 @@ void MidiOutJack :: sendMessage( const unsigned char *message, size_t size )
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
 
   // Write full message to buffer
-  jack_ringbuffer_write( data->buffMessage, ( const char * ) message,
-                         nBytes );
+  jack_ringbuffer_write( data->buffMessage, ( const char * ) message, nBytes );
   jack_ringbuffer_write( data->buffSize, ( char * ) &nBytes, sizeof( nBytes ) );
 }
 

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -89,8 +89,9 @@ class RTMIDI_DLL_PUBLIC RtMidiError : public std::exception
   };
 
   //! The constructor.
-  RtMidiError( const std::string& message, Type type = RtMidiError::UNSPECIFIED ) throw() : message_(message), type_(type) {}
- 
+  RtMidiError( const std::string& message, Type type = RtMidiError::UNSPECIFIED ) throw()
+    : message_(message), type_(type) {}
+
   //! The destructor.
   virtual ~RtMidiError( void ) throw() {}
 
@@ -98,10 +99,10 @@ class RTMIDI_DLL_PUBLIC RtMidiError : public std::exception
   virtual void printMessage( void ) const throw() { std::cerr << '\n' << message_ << "\n\n"; }
 
   //! Returns the thrown error message type.
-  virtual const Type& getType(void) const throw() { return type_; }
+  virtual const Type& getType( void ) const throw() { return type_; }
 
   //! Returns the thrown error message string.
-  virtual const std::string& getMessage(void) const throw() { return message_; }
+  virtual const std::string& getMessage( void ) const throw() { return message_; }
 
   //! Returns the thrown error message as a c-style string.
   virtual const char* what( void ) const throw() { return message_.c_str(); }
@@ -126,7 +127,6 @@ class MidiApi;
 class RTMIDI_DLL_PUBLIC RtMidi
 {
  public:
-
   //! MIDI API specifier arguments.
   enum Api {
     UNSPECIFIED,    /*!< Search for a working compiled API. */
@@ -181,10 +181,8 @@ class RTMIDI_DLL_PUBLIC RtMidi
   virtual void setErrorCallback( RtMidiErrorCallback errorCallback = NULL, void *userData = 0 ) = 0;
 
  protected:
-
   RtMidi();
   virtual ~RtMidi();
-
   MidiApi *rtapi_;
 };
 
@@ -225,7 +223,7 @@ class RTMIDI_DLL_PUBLIC RtMidiIn : public RtMidi
  public:
 
   //! User callback function type definition.
-  typedef void (*RtMidiCallback)( double timeStamp, std::vector<unsigned char> *message, void *userData);
+  typedef void (*RtMidiCallback)( double timeStamp, std::vector<unsigned char> *message, void *userData );
 
   //! Default constructor that allows an optional api, client name and queue size.
   /*!
@@ -348,7 +346,6 @@ class RTMIDI_DLL_PUBLIC RtMidiIn : public RtMidi
 
  protected:
   void openMidiApi( RtMidi::Api api, const std::string &clientName, unsigned int queueSizeLimit );
-
 };
 
 /**********************************************************************/
@@ -370,7 +367,6 @@ class RTMIDI_DLL_PUBLIC RtMidiIn : public RtMidi
 class RTMIDI_DLL_PUBLIC RtMidiOut : public RtMidi
 {
  public:
-
   //! Default constructor that allows an optional client name.
   /*!
     An exception will be thrown if a MIDI system initialization error occurs.
@@ -517,15 +513,15 @@ class RTMIDI_DLL_PUBLIC MidiInApi : public MidiApi
 
   // A MIDI structure used internally by the class to store incoming
   // messages.  Each message represents one and only one MIDI message.
-  struct MidiMessage { 
-    std::vector<unsigned char> bytes; 
+  struct MidiMessage {
+    std::vector<unsigned char> bytes;
 
     //! Time in seconds elapsed since the previous message
     double timeStamp;
 
     // Default constructor.
-  MidiMessage()
-  :bytes(0), timeStamp(0.0) {}
+    MidiMessage()
+      : bytes(0), timeStamp(0.0) {}
   };
 
   struct MidiQueue {
@@ -535,12 +531,11 @@ class RTMIDI_DLL_PUBLIC MidiInApi : public MidiApi
     MidiMessage *ring;
 
     // Default constructor.
-  MidiQueue()
-  :front(0), back(0), ringSize(0), ring(0) {}
-    bool push(const MidiMessage&);
-    bool pop(std::vector<unsigned char>*, double*);
-    unsigned int size(unsigned int *back=0,
-		      unsigned int *front=0);
+    MidiQueue()
+      : front(0), back(0), ringSize(0), ring(0) {}
+    bool push( const MidiMessage& );
+    bool pop( std::vector<unsigned char>*, double* );
+    unsigned int size( unsigned int *back=0, unsigned int *front=0 );
   };
 
   // The RtMidiInData structure is used to pass private class data to
@@ -558,10 +553,9 @@ class RTMIDI_DLL_PUBLIC MidiInApi : public MidiApi
     bool continueSysex;
 
     // Default constructor.
-  RtMidiInData()
-  : ignoreFlags(7), doInput(false), firstMessage(true),
-      apiData(0), usingCallback(false), userCallback(0), userData(0),
-      continueSysex(false) {}
+    RtMidiInData()
+      : ignoreFlags(7), doInput(false), firstMessage(true), apiData(0), usingCallback(false),
+        userCallback(0), userData(0), continueSysex(false) {}
   };
 
  protected:
@@ -594,7 +588,7 @@ inline unsigned int RtMidiIn :: getPortCount( void ) { return rtapi_->getPortCou
 inline std::string RtMidiIn :: getPortName( unsigned int portNumber ) { return rtapi_->getPortName( portNumber ); }
 inline void RtMidiIn :: ignoreTypes( bool midiSysex, bool midiTime, bool midiSense ) { ((MidiInApi *)rtapi_)->ignoreTypes( midiSysex, midiTime, midiSense ); }
 inline double RtMidiIn :: getMessage( std::vector<unsigned char> *message ) { return ((MidiInApi *)rtapi_)->getMessage( message ); }
-inline void RtMidiIn :: setErrorCallback( RtMidiErrorCallback errorCallback, void *userData ) { rtapi_->setErrorCallback(errorCallback, userData); }
+inline void RtMidiIn :: setErrorCallback( RtMidiErrorCallback errorCallback, void *userData ) { rtapi_->setErrorCallback( errorCallback, userData ); }
 
 inline RtMidi::Api RtMidiOut :: getCurrentApi( void ) throw() { return rtapi_->getCurrentApi(); }
 inline void RtMidiOut :: openPort( unsigned int portNumber, const std::string &portName ) { rtapi_->openPort( portNumber, portName ); }
@@ -605,6 +599,6 @@ inline unsigned int RtMidiOut :: getPortCount( void ) { return rtapi_->getPortCo
 inline std::string RtMidiOut :: getPortName( unsigned int portNumber ) { return rtapi_->getPortName( portNumber ); }
 inline void RtMidiOut :: sendMessage( const std::vector<unsigned char> *message ) { ((MidiOutApi *)rtapi_)->sendMessage( &message->at(0), message->size() ); }
 inline void RtMidiOut :: sendMessage( const unsigned char *message, size_t size ) { ((MidiOutApi *)rtapi_)->sendMessage( message, size ); }
-inline void RtMidiOut :: setErrorCallback( RtMidiErrorCallback errorCallback, void *userData ) { rtapi_->setErrorCallback(errorCallback, userData); }
+inline void RtMidiOut :: setErrorCallback( RtMidiErrorCallback errorCallback, void *userData ) { rtapi_->setErrorCallback( errorCallback, userData ); }
 
 #endif


### PR DESCRIPTION
This is a whitespace / line-breaks change only. No changes in the actual code or functionality.

* Fixes inconsistent indentation of if/else statements, blocks, function parameters and class attribute initializers.
* Fixes inconsistent whitespace within parentheses.
* Removes trailing whitespace.
* Replaces tabs with spaces.
