### PR TITLE
Improve gitignore rules to ignore most generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,61 @@
-/config
-/configure
-/Makefile.in
 /aclocal.m4
 /autom4te.cache
+/config
+/config.log
+/config.status
 /configure
+/libtool
+/rtmidi-config
+/rtmidi.pc
 /m4
+
+/Makefile
+/Makefile.in
+/doc/Makefile
 /doc/Makefile.in
+/tests/Makefile
 /tests/Makefile.in
+
+/doc/html
+/doc/doxygen-build.stamp
+/doc/doxygen/Doxyfile
+
 /build*/
+
+/.deps
+/.libs
+/tests/.deps
+/tests/.libs
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app


### PR DESCRIPTION
The only files generated by a build, which are not in this ignore list yet, are the test program binaries. The can't really be ignored via a simple pattern and I didn't want to list them individually. But I can enhance this PR by adding them as well, if so desired.