### PR TITLE
Changes to CMakeLists to make use with add_subdirectory easier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,11 @@ if(WIN32)
 endif()
 
 # Build Options
-option(BUILD_SHARED_LIBS "Compile library shared lib." TRUE)
-option(BUILD_STATIC_LIBS "Compile library static lib." TRUE)
-option(BUILD_TESTING "Compile test programs." TRUE)
+option(RTMIDI_BUILD_SHARED_LIBS "Compile library shared lib." TRUE)
+option(RTMIDI_BUILD_STATIC_LIBS "Compile library static lib." TRUE)
+option(RTMIDI_BUILD_TESTING "Compile test programs." TRUE)
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type (Release,Debug)")
+set(RTMIDI_TARGETNAME_UNINSTALL "uninstall" CACHE STRING "Name of 'uninstall' build target")
 
 # API Options
 option(RTMIDI_API_JACK "Compile with JACK support." ${HAVE_JACK})
@@ -136,7 +137,7 @@ endif()
 # Create library targets.
 cmake_policy(SET CMP0042 OLD)
 set(LIB_TARGETS)
-if(BUILD_SHARED_LIBS)
+if(RTMIDI_BUILD_SHARED_LIBS)
   add_library(rtmidi SHARED ${rtmidi_SOURCES})
   list(APPEND LIB_TARGETS rtmidi)
 
@@ -157,7 +158,7 @@ if(BUILD_SHARED_LIBS)
   target_link_libraries(rtmidi ${LINKLIBS})
 endif()
 
-if(BUILD_STATIC_LIBS)
+if(RTMIDI_BUILD_STATIC_LIBS)
   add_library(rtmidi_static STATIC ${rtmidi_SOURCES})
   list(APPEND LIB_TARGETS rtmidi_static)
 
@@ -182,7 +183,7 @@ endif()
 include(GNUInstallDirs)
 
 # Add tests if requested.
-if(BUILD_TESTING)
+if(RTMIDI_BUILD_TESTING)
   add_executable(cmidiin    tests/cmidiin.cpp)
   add_executable(midiclock  tests/midiclock.cpp)
   add_executable(midiout    tests/midiout.cpp)
@@ -206,7 +207,7 @@ message(STATUS "Compiling with support for: ${apilist}")
 # PkgConfig file
 string(REPLACE ";" " " req "${PKGCONFIG_REQUIRES}")
 string(REPLACE ";" " " api "${API_DEFS}")
-configure_file("rtmidi.pc.in" "rtmidi.pc" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/rtmidi.pc.in" "rtmidi.pc" @ONLY)
 
 # Add install rule.
 install(TARGETS ${LIB_TARGETS}
@@ -248,7 +249,7 @@ configure_file(
     "${CMAKE_BINARY_DIR}/RtMidiConfigUninstall.cmake" @ONLY)
 
 # Create uninstall target.
-add_custom_target(uninstall
+add_custom_target(${RTMIDI_TARGETNAME_UNINSTALL}
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}/RtMidiConfigUninstall.cmake)
 
 install(


### PR DESCRIPTION
There's a common technique with CMake where instead of building and installing your dependencies, you check your dependencies into your project as git submodules and then use add_subdirectory to make them build at the same time your project builds. This is good because it gets you reproducible builds and your versioning is enforced by git.

Right now RTMIDI does not work with add_subdirectory because it has variables/targets that are likely to namespace collide with other CMakeLists. For example right now if you use add_subdirectory to include RTMIDI and PhysFS in the same build it cannot build because they both declare a target named "uninstall" and CMake bails out when it sees this.

This patch fixes this by:

- "Namespace" option variables with RTMIDI_
- New RTMIDI_TARGETNAME_UNINSTALL option to optionally rename uninstall target

**Another thing that would help but is not in this patch** is if the source were moved into a src/ directory or the sources and includes moved into src/ and include/ directory. Right now when doing the add_subdirectory thing you have to include_directories() the whole RTMIDI project folder and this means the include path gets polluted with, like, your tests directory and stuff.