### PR TITLE
Implement sendMessages

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -2293,7 +2293,7 @@ void MidiOutAlsa :: openVirtualPort( const std::string &portName )
 
 void MidiOutAlsa :: sendMessage( const unsigned char *message, size_t size )
 {
-  int result;
+  long result;
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   unsigned int nBytes = static_cast<unsigned int> (size);
   if ( nBytes > data->bufferSize ) {
@@ -2313,25 +2313,38 @@ void MidiOutAlsa :: sendMessage( const unsigned char *message, size_t size )
     }
   }
 
-  snd_seq_event_t ev;
-  snd_seq_ev_clear( &ev );
-  snd_seq_ev_set_source( &ev, data->vport );
-  snd_seq_ev_set_subs( &ev );
-  snd_seq_ev_set_direct( &ev );
   for ( unsigned int i=0; i<nBytes; ++i ) data->buffer[i] = message[i];
-  result = snd_midi_event_encode( data->coder, data->buffer, (long)nBytes, &ev );
-  if ( result < (int)nBytes ) {
-    errorString_ = "MidiOutAlsa::sendMessage: event parsing error!";
-    error( RtMidiError::WARNING, errorString_ );
-    return;
-  }
 
-  // Send the event.
-  result = snd_seq_event_output( data->seq, &ev );
-  if ( result < 0 ) {
-    errorString_ = "MidiOutAlsa::sendMessage: error sending MIDI message to port.";
-    error( RtMidiError::WARNING, errorString_ );
-    return;
+  unsigned int offset = 0;
+  while (offset < nBytes) {
+    snd_seq_event_t ev;
+    snd_seq_ev_clear( &ev );
+    snd_seq_ev_set_source( &ev, data->vport );
+    snd_seq_ev_set_subs( &ev );
+    snd_seq_ev_set_direct( &ev );
+    result = snd_midi_event_encode( data->coder, data->buffer + offset,
+                                    (long)(nBytes - offset), &ev );
+    if ( result < 0 ) {
+      errorString_ = "MidiOutAlsa::sendMessage: event parsing error!";
+      error( RtMidiError::WARNING, errorString_ );
+      return;
+    }
+
+    if ( ev.type == SND_SEQ_EVENT_NONE ) {
+      errorString_ = "MidiOutAlsa::sendMessage: incomplete message!";
+      error( RtMidiError::WARNING, errorString_ );
+      return;
+    }
+
+    offset += result;
+
+    // Send the event.
+    result = snd_seq_event_output( data->seq, &ev );
+    if ( result < 0 ) {
+      errorString_ = "MidiOutAlsa::sendMessage: error sending MIDI message to port.";
+      error( RtMidiError::WARNING, errorString_ );
+      return;
+    }
   }
   snd_seq_drain_output( data->seq );
 }


### PR DESCRIPTION
Some backends may have an lower-latency way to send out multiple messages at once rather than one at time. This API allows clients to take advantage of that capability.

The first implementation is for `MidiOutAlsa`, which can buffer multiple messages at once before draining them out over the alsa pipe.