### PR TITLE
Fix Go binding compilation error

### DIFF
--- a/contrib/go/rtmidi/rtmidi.go
+++ b/contrib/go/rtmidi/rtmidi.go
@@ -72,7 +72,7 @@ func (api API) String() string {
 func CompiledAPI() (apis []API) {
 	n := C.rtmidi_get_compiled_api(nil, 0)
 	capis := make([]C.enum_RtMidiApi, n, n)
-	C.rtmidi_get_compiled_api(&capis[0], _Ctype_uint(n))
+	C.rtmidi_get_compiled_api(&capis[0], C.uint(n))
 	for _, capi := range capis {
 		apis = append(apis, API(capi))
 	}


### PR DESCRIPTION
This code failed to build on Go 1.12 with the error:

`rtmidi.go:75:39: identifier "_Ctype_uint" may conflict with identifiers generated by cgo`

This change seems to be the proper way to convert between C types in cgo and fixes this error.