### PR TITLE
Add coremidi to the api list when compiling with coremidi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ endif()
 # CoreMIDI
 if(RTMIDI_API_CORE)
   list(APPEND API_DEFS "-D__MACOSX_CORE__")
+  list(APPEND API_LIST "coremidi")
   list(APPEND LINKLIBS "-framework CoreServices")
   list(APPEND LINKLIBS "-framework CoreAudio")
   list(APPEND LINKLIBS "-framework CoreMIDI")


### PR DESCRIPTION
CoreMidi seems to have been left out of the api list, leaving it empty when
compiling on macOS.