### PR TITLE
Make include folder public.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ set_target_properties(rtmidi PROPERTIES PUBLIC_HEADER RtMidi.h
   VERSION ${FULL_VER})
 
 # Set include paths, populate target interface.
-target_include_directories(rtmidi PRIVATE
+target_include_directories(rtmidi PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   ${INCDIRS})


### PR DESCRIPTION
This way, when a parent project depends on the `rtmidi` target
(e.g. in a git submodule configuration) it will be able to see
its header file.