### PR TITLE
Delete trailing whitespaces.

### DIFF
--- a/rtmidi.pc.in
+++ b/rtmidi.pc.in
@@ -6,7 +6,7 @@ includedir=${prefix}/include/rtmidi
 Name: librtmidi
 Description: RtMidi - a set of C++ classes that provide a common API for realtime MIDI input/output
 Version: @PACKAGE_VERSION@
-Requires: @req@ 
+Requires: @req@
 Libs: -L${libdir} -lrtmidi
 Libs.private: -lpthread
 Cflags: -pthread -I${includedir} @api@

--- a/rtmidi_c.cpp
+++ b/rtmidi_c.cpp
@@ -89,7 +89,7 @@ void rtmidi_open_port (RtMidiPtr device, unsigned int portNumber, const char *po
     std::string name = portName;
     try {
         ((RtMidi*) device->ptr)->openPort (portNumber, name);
-    
+
     } catch (const RtMidiError & err) {
         device->ok  = false;
         device->msg = err.what ();
@@ -101,7 +101,7 @@ void rtmidi_open_virtual_port (RtMidiPtr device, const char *portName)
     std::string name = portName;
     try {
         ((RtMidi*) device->ptr)->openVirtualPort (name);
-    
+
     } catch (const RtMidiError & err) {
         device->ok  = false;
         device->msg = err.what ();
@@ -111,7 +111,7 @@ void rtmidi_open_virtual_port (RtMidiPtr device, const char *portName)
 
 void rtmidi_close_port (RtMidiPtr device)
 {
-    try { 
+    try {
         ((RtMidi*) device->ptr)->closePort ();
 
     } catch (const RtMidiError & err) {
@@ -137,7 +137,7 @@ const char* rtmidi_get_port_name (RtMidiPtr device, unsigned int portNumber)
     try {
         std::string name = ((RtMidi*) device->ptr)->getPortName (portNumber);
         return strdup (name.c_str ());
-    
+
     } catch (const RtMidiError & err) {
         device->ok  = false;
         device->msg = err.what ();
@@ -149,15 +149,15 @@ const char* rtmidi_get_port_name (RtMidiPtr device, unsigned int portNumber)
 RtMidiInPtr rtmidi_in_create_default ()
 {
     RtMidiWrapper* wrp = new RtMidiWrapper;
-    
+
     try {
         RtMidiIn* rIn = new RtMidiIn ();
-        
+
         wrp->ptr = (void*) rIn;
         wrp->data = 0;
         wrp->ok  = true;
         wrp->msg = "";
-    
+
     } catch (const RtMidiError & err) {
         wrp->ptr = 0;
         wrp->data = 0;
@@ -172,10 +172,10 @@ RtMidiInPtr rtmidi_in_create (enum RtMidiApi api, const char *clientName, unsign
 {
     std::string name = clientName;
     RtMidiWrapper* wrp = new RtMidiWrapper;
-    
+
     try {
         RtMidiIn* rIn = new RtMidiIn ((RtMidi::Api) api, name, queueSizeLimit);
-        
+
         wrp->ptr = (void*) rIn;
         wrp->data = 0;
         wrp->ok  = true;
@@ -203,7 +203,7 @@ enum RtMidiApi rtmidi_in_get_current_api (RtMidiPtr device)
 {
     try {
         return (RtMidiApi) ((RtMidiIn*) device->ptr)->getCurrentApi ();
-    
+
     } catch (const RtMidiError & err) {
         device->ok  = false;
         device->msg = err.what ();
@@ -249,7 +249,7 @@ void rtmidi_in_ignore_types (RtMidiInPtr device, bool midiSysex, bool midiTime, 
 	((RtMidiIn*) device->ptr)->ignoreTypes (midiSysex, midiTime, midiSense);
 }
 
-double rtmidi_in_get_message (RtMidiInPtr device, 
+double rtmidi_in_get_message (RtMidiInPtr device,
                               unsigned char *message,
                               size_t *size)
 {
@@ -264,7 +264,7 @@ double rtmidi_in_get_message (RtMidiInPtr device,
 
         *size = v.size();
         return ret;
-    } 
+    }
     catch (const RtMidiError & err) {
         device->ok  = false;
         device->msg = err.what ();
@@ -284,12 +284,12 @@ RtMidiOutPtr rtmidi_out_create_default ()
 
     try {
         RtMidiOut* rOut = new RtMidiOut ();
-        
+
         wrp->ptr = (void*) rOut;
         wrp->data = 0;
         wrp->ok  = true;
         wrp->msg = "";
-    
+
     } catch (const RtMidiError & err) {
         wrp->ptr = 0;
         wrp->data = 0;
@@ -307,12 +307,12 @@ RtMidiOutPtr rtmidi_out_create (enum RtMidiApi api, const char *clientName)
 
     try {
         RtMidiOut* rOut = new RtMidiOut ((RtMidi::Api) api, name);
-        
+
         wrp->ptr = (void*) rOut;
         wrp->data = 0;
         wrp->ok  = true;
         wrp->msg = "";
-    
+
     } catch (const RtMidiError & err) {
         wrp->ptr = 0;
         wrp->data = 0;

--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -41,7 +41,7 @@ struct RtMidiWrapper {
     void* ptr;
     void* data;
 
-    //! True when the last function call was OK. 
+    //! True when the last function call was OK.
     bool  ok;
 
     //! If an error occured (ok != true), set to an error message.
@@ -136,8 +136,8 @@ RTMIDIAPI void rtmidi_error (enum RtMidiErrorType type, const char* errorString)
  */
 RTMIDIAPI void rtmidi_open_port (RtMidiPtr device, unsigned int portNumber, const char *portName);
 
-/*! \brief Creates a virtual MIDI port to which other software applications can 
- * connect.  
+/*! \brief Creates a virtual MIDI port to which other software applications can
+ * connect.
  *
  * \param portName  Name for the application port.
  *
@@ -203,8 +203,8 @@ RTMIDIAPI void rtmidi_in_ignore_types (RtMidiInPtr device, bool midiSysex, bool 
  * \param message   Must point to a char* that is already allocated.
  *                  SYSEX messages maximum size being 1024, a statically
  *                  allocated array could
- *                  be sufficient. 
- * \param size      Is used to return the size of the message obtained. 
+ *                  be sufficient.
+ * \param size      Is used to return the size of the message obtained.
  *
  * See RtMidiIn::getMessage().
  */


### PR DESCRIPTION
They are indifferent to some users, and pollute diffs for other ones.