### PR TITLE
Expose include path for RtMidi.h in target rtmidi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,9 +179,10 @@ set_target_properties(rtmidi PROPERTIES PUBLIC_HEADER RtMidi.h
   VERSION ${FULL_VER})
 
 # Set include paths, populate target interface.
-target_include_directories(rtmidi PRIVATE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+target_include_directories(rtmidi PUBLIC
+  $<INSTALL_INTERFACE:include>
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+  PRIVATE
   ${INCDIRS})
 
 # Set compile-time definitions


### PR DESCRIPTION
Currently I need to manually add the include-path for RtMidi.h when using RtMidi. With this pull-request this will not be necessary any more and 

find_package(RtMidi REQUIRED)
target_link_libraries(my-target PRIVATE RtMidi::rtmidi)

will be all that is required to use your library, which is more elegant and less error-prone than manually configuring the include path. Hope you like it:)