### PR TITLE
[CMakeLists] Remove line 154 cmake_policy(SET CMP0042 OLD)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,6 @@ if (NEED_PTHREAD)
 endif()
 
 # Create library targets.
-cmake_policy(SET CMP0042 OLD)
 set(LIB_TARGETS)
 
 # Use RTMIDI_BUILD_SHARED_LIBS / RTMIDI_BUILD_STATIC_LIBS if they


### PR DESCRIPTION
This command is only needed by:
	- users of Xcode <3.0 (2009) and macOS <10.5
	- users of CMake older than 3.0.
They can still set to OLD as necessary.
Other CMakers get an error and have to edit CMakeLists.txt.

Here is the link to the policy details.
https://cmake.org/cmake/help/latest/policy/CMP0042.html

Here is a link explaining why and how to use @rpath:
https://www.dribin.org/dave/blog/archives/2009/11/15/rpath/

The OLD behaviour of a policy is deprecated by definition.
CMake 3.16.0-rc3 is the current version.
MACOSX_RPATH is enabled by default.