### PR TITLE
clarify that the value of param size is used by rtmidi_in_get_message

### DIFF
--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -205,6 +205,7 @@ RTMIDIAPI void rtmidi_in_ignore_types (RtMidiInPtr device, bool midiSysex, bool 
  *                  allocated array could
  *                  be sufficient.
  * \param size      Is used to return the size of the message obtained.
+ *                  Must be set to the size of \ref message when calling.
  *
  * See RtMidiIn::getMessage().
  */


### PR DESCRIPTION
It took me a while to figure out what was going wrong because I was passing an uninitialized variable for the size, but apparently the function uses it to check if it's large enough to hold the message. 

```C
double rtmidi_in_get_message (RtMidiInPtr device,
                              unsigned char *message,
                              size_t *size)
{
    try {
        // FIXME: use allocator to achieve efficient buffering
        std::vector<unsigned char> v;
        double ret = ((RtMidiIn*) device->ptr)->getMessage (&v);

        if (v.size () > 0 && v.size() <= *size) { // <---------- here
            memcpy (message, v.data (), (int) v.size ());
        }

        *size = v.size();
        return ret;
    }
    catch (const RtMidiError & err) {
        device->ok  = false;
        device->msg = err.what ();
        return -1;
    }
    catch (...) {
        device->ok  = false;
        device->msg = "Unknown error";
        return -1;
    }
}
```

I've never seen another API do that - i expected it to only be an output param - so I think it should be clarified.