### PR TITLE
Fix memory leak from rtmidi_get_port_name

### DIFF
--- a/rtmidi_c.cpp
+++ b/rtmidi_c.cpp
@@ -132,17 +132,27 @@ unsigned int rtmidi_get_port_count (RtMidiPtr device)
     }
 }
 
-const char* rtmidi_get_port_name (RtMidiPtr device, unsigned int portNumber)
+int rtmidi_get_port_name (RtMidiPtr device, unsigned int portNumber, char * bufOut, int * bufLen)
 {
-    try {
-        std::string name = ((RtMidi*) device->ptr)->getPortName (portNumber);
-        return strdup (name.c_str ());
+    if (bufOut == nullptr && bufLen == nullptr) {
+        return -1;
+    }
 
+    std::string name;
+    try {
+        name = ((RtMidi*) device->ptr)->getPortName (portNumber);
     } catch (const RtMidiError & err) {
         device->ok  = false;
         device->msg = err.what ();
-        return "";
+        return -1;
     }
+
+    if (bufOut == nullptr) {
+        *bufLen = static_cast<int>(name.size());
+        return 0;
+    }
+
+    return snprintf(bufOut, static_cast<size_t>(*bufLen), "%s", name.c_str());
 }
 
 /* RtMidiIn API */

--- a/rtmidi_c.cpp
+++ b/rtmidi_c.cpp
@@ -148,7 +148,7 @@ int rtmidi_get_port_name (RtMidiPtr device, unsigned int portNumber, char * bufO
     }
 
     if (bufOut == nullptr) {
-        *bufLen = static_cast<int>(name.size());
+        *bufLen = static_cast<int>(name.size()) + 1;
         return 0;
     }
 

--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -155,10 +155,14 @@ RTMIDIAPI void rtmidi_close_port (RtMidiPtr device);
  */
 RTMIDIAPI unsigned int rtmidi_get_port_count (RtMidiPtr device);
 
-/*! \brief Return a string identifier for the specified MIDI input port number.
+/*! \brief Access a string identifier for the specified MIDI input port number.
+ * 
+ * To prevent memory leaks a char buffer must be passed to this function.
+ * NULL can be passed as bufOut parameter, and that will write the required buffer length in the bufLen.
+ * 
  * See RtMidi::getPortName().
  */
-RTMIDIAPI const char* rtmidi_get_port_name (RtMidiPtr device, unsigned int portNumber);
+RTMIDIAPI int rtmidi_get_port_name (RtMidiPtr device, unsigned int portNumber, char * bufOut, int * bufLen);
 
 /* RtMidiIn API */
 


### PR DESCRIPTION
The address sanitizer warned of a leak in our code linked to rtmidi_get_port_name. One fix could be to just let the recipient of the char * free it. But when compiled as a dll I think that can lead to strange behavior if the standard libraries used in dll and main application differ. So I propose changing the interface of the rtmidi_get_port_name function so the user of it provides a char buffer for it to write into.