### PR TITLE
Added option to MidiApi to stop printing errors and warnings

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -533,6 +533,12 @@ RtMidiOut :: ~RtMidiOut() throw()
 //*********************************************************************//
 //  Common MidiApi Definitions
 //*********************************************************************//
+bool MidiApi :: printErrorIfNoCallback_ = false;
+
+void MidiApi:: printErrorIfNoCallback(bool print)
+{
+    printErrorIfNoCallback_ = print;
+};
 
 MidiApi :: MidiApi( void )
   : apiData_( 0 ), connected_( false ), errorCallback_(0), firstErrorOccurred_(false), errorCallbackUserData_(0)
@@ -565,7 +571,8 @@ void MidiApi :: error( RtMidiError::Type type, std::string errorString )
   }
 
   if ( type == RtMidiError::WARNING ) {
-    std::cerr << '\n' << errorString << "\n\n";
+      if ( printErrorIfNoCallback_ )
+        std::cerr << '\n' << errorString << "\n\n";
   }
   else if ( type == RtMidiError::DEBUG_WARNING ) {
 #if defined(__RTMIDI_DEBUG__)
@@ -573,7 +580,8 @@ void MidiApi :: error( RtMidiError::Type type, std::string errorString )
 #endif
   }
   else {
-    std::cerr << '\n' << errorString << "\n\n";
+    if (printErrorIfNoCallback_)
+      std::cerr << '\n' << errorString << "\n\n";
     throw RtMidiError( errorString, type );
   }
 }

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -496,6 +496,12 @@ class RTMIDI_DLL_PUBLIC MidiApi
 {
  public:
 
+  //! Set a boolean to avoid printing error messages to the error stream when no error callback is setup.
+  /*!
+      \param print True to print error messages to the error stream when no callback setup, false to not do so.
+   */
+  static void printErrorIfNoCallback(bool print);;
+
   MidiApi();
   virtual ~MidiApi();
   virtual RtMidi::Api getCurrentApi( void ) = 0;
@@ -517,6 +523,7 @@ class RTMIDI_DLL_PUBLIC MidiApi
 protected:
   virtual void initialize( const std::string& clientName ) = 0;
 
+  static bool printErrorIfNoCallback_;
   void *apiData_;
   bool connected_;
   std::string errorString_;


### PR DESCRIPTION
Added a static function to MidiApi to be able to stop printing warnings and errors to the console.
This is especially useful when RtMidi object is initialised with no device connected yet, we don't necessary want a warning being printed.