### PR TITLE
CMake: Minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,7 @@ message(STATUS "Compiling with support for: ${apilist}")
 # PkgConfig file
 string(REPLACE ";" " " req "${PKGCONFIG_REQUIRES}")
 string(REPLACE ";" " " api "${API_DEFS}")
+set(prefix ${CMAKE_INSTALL_PREFIX})
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/rtmidi.pc.in" "rtmidi.pc" @ONLY)
 
 # Add install rule.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ if(RTMIDI_API_JACK)
   check_symbol_exists(jack_port_rename ${jack_INCLUDEDIR}/jack/jack.h JACK_HAS_PORT_RENAME)
   set(CMAKE_REQUIRED_LIBRARIES ${tmp_CMAKE_REQUIRED_LIBRARIES})
   if(JACK_HAS_PORT_RENAME)
-    list(APPEND API_DEFS "JACK_HAS_PORT_RENAME")
+    list(APPEND API_DEFS "-DJACK_HAS_PORT_RENAME")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,8 @@ endif()
 list(APPEND LIB_TARGETS rtmidi)
 
 # Add headers destination for install rule.
-set_target_properties(rtmidi PROPERTIES PUBLIC_HEADER RtMidi.h
+set_property(TARGET rtmidi PROPERTY PUBLIC_HEADER RtMidi.h rtmidi_c.h)
+set_target_properties(rtmidi PROPERTIES
   SOVERSION ${SO_VER}
   VERSION ${FULL_VER})
 
@@ -232,7 +233,7 @@ install(TARGETS ${LIB_TARGETS}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rtmidi)
 
 # Store the package in the user registry.
 export(PACKAGE RtMidi)


### PR DESCRIPTION
A `-D` is missing when defining `JACK_HAS_PORT_RENAME`, which compiles fine but causes malformed cflags in the pkgconfig file
```
Cflags: -pthread -I${includedir} -D__UNIX_JACK__ JACK_HAS_PORT_RENAME -D__LINUX_ALSA__
```
leading to compilation failures in depending projects.
> g++: error: JACK_HAS_PORT_RENAME: No such file or directory

---

The `prefix` variable in the pkg-config file is never defined prior to its substitution, resulting in an empty prefix value no matter what the user defined. This may cause compiling & linking issues if the lib & header variables fail to resolve relative to the user's desired, non-standard prefix.
```
prefix=
```
After fix:
```
prefix=/nix/store/id9a2ll55pkshhgji0mn4gk6xzxnhqx5-rtmidi-4.0.0
```

---

The CMake build installs the wrong amount of headers to the wrong directory, compared to autotools.

autotools: RtMidi.h & rtmidi\_c.h → /usr/local/include/rtmidi/
CMake: RtMidi.h → /usr/local/include/

Fix is identical to https://github.com/thestk/rtaudio/commit/4273cf7572b8f51b5996cf6b42e3699cc6b165da, lack of the headers was mentioned in #229.