### PR TITLE
Make RtMidi class non-copyable

### DIFF
--- a/RtMidi.h
+++ b/RtMidi.h
@@ -213,6 +213,10 @@ class RTMIDI_DLL_PUBLIC RtMidi
   RtMidi();
   virtual ~RtMidi();
   MidiApi *rtapi_;
+
+  /* Make the class non-copyable */
+  RtMidi(RtMidi& other) = delete;
+  RtMidi& operator=(RtMidi& other) = delete;
 };
 
 /**********************************************************************/


### PR DESCRIPTION
Hi,

I was trying to use a `std::vector<RtMidiIn>` to keep a list of open MIDI ports.

My code was crashing for some reason.

I discovered that the implementation of std::vector was copying the whole internal array when I added instances of `RtMidiIn` to the end.

However, copying instances RtMidiIn seems to break them (at least, on Windows). There is no defined copy constructor.

For now, I have added some code so that if a user attempts to build code that involves copying an RtMidi instance, the compiler will fail, hopefully saving someone else some debugging time.