### PR TITLE
Make RtMidi moveable and non-copyable

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -305,6 +305,11 @@ RtMidi :: ~RtMidi()
   rtapi_ = 0;
 }
 
+RtMidi::RtMidi(RtMidi&& other) noexcept { 
+    rtapi_ = other.rtapi_; 
+    other.rtapi_ = nullptr; 
+}
+
 std::string RtMidi :: getVersion( void ) throw()
 {
   return std::string( RTMIDI_VERSION );

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -305,7 +305,7 @@ RtMidi :: ~RtMidi()
   rtapi_ = 0;
 }
 
-RtMidi::RtMidi(RtMidi&& other) noexcept { 
+RtMidi::RtMidi(RtMidi&& other) RTMIDI_NOEXCEPT { 
     rtapi_ = other.rtapi_; 
     other.rtapi_ = nullptr; 
 }

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -213,6 +213,10 @@ class RTMIDI_DLL_PUBLIC RtMidi
   RtMidi();
   virtual ~RtMidi();
   MidiApi *rtapi_;
+
+  /* Make the class non-copyable */
+  RtMidi(RtMidi& other) = delete;
+  RtMidi& operator=(RtMidi& other) = delete;
 };
 
 /**********************************************************************/

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -132,6 +132,8 @@ class MidiApi;
 class RTMIDI_DLL_PUBLIC RtMidi
 {
  public:
+
+     RtMidi(RtMidi&& other) noexcept;
   //! MIDI API specifier arguments.
   enum Api {
     UNSPECIFIED,    /*!< Search for a working compiled API. */
@@ -252,7 +254,6 @@ class RTMIDI_DLL_PUBLIC RtMidi
 class RTMIDI_DLL_PUBLIC RtMidiIn : public RtMidi
 {
  public:
-
   //! User callback function type definition.
   typedef void (*RtMidiCallback)( double timeStamp, std::vector<unsigned char> *message, void *userData );
 
@@ -277,6 +278,8 @@ class RTMIDI_DLL_PUBLIC RtMidiIn : public RtMidi
   RtMidiIn( RtMidi::Api api=UNSPECIFIED,
             const std::string& clientName = "RtMidi Input Client",
             unsigned int queueSizeLimit = 100 );
+
+  RtMidiIn(RtMidiIn&& other) noexcept : RtMidi(std::move(other)) { }
 
   //! If a MIDI connection is still open, it will be closed by the destructor.
   ~RtMidiIn ( void ) throw();
@@ -406,6 +409,8 @@ class RTMIDI_DLL_PUBLIC RtMidiOut : public RtMidi
   */
   RtMidiOut( RtMidi::Api api=UNSPECIFIED,
              const std::string& clientName = "RtMidi Output Client" );
+
+  RtMidiOut(RtMidiOut&& other) noexcept : RtMidi(std::move(other)) { }
 
   //! The destructor closes any open MIDI connections.
   ~RtMidiOut( void ) throw();

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -58,6 +58,12 @@
   #endif
 #endif
 
+#if __cplusplus >= 201103L
+    #define RTMIDI_NOEXCEPT noexcept
+#else
+    #define RTMIDI_NOEXCEPT throw()
+#endif
+
 #define RTMIDI_VERSION "4.0.0"
 
 #include <exception>
@@ -133,7 +139,7 @@ class RTMIDI_DLL_PUBLIC RtMidi
 {
  public:
 
-     RtMidi(RtMidi&& other) noexcept;
+     RtMidi(RtMidi&& other) RTMIDI_NOEXCEPT;
   //! MIDI API specifier arguments.
   enum Api {
     UNSPECIFIED,    /*!< Search for a working compiled API. */
@@ -279,7 +285,7 @@ class RTMIDI_DLL_PUBLIC RtMidiIn : public RtMidi
             const std::string& clientName = "RtMidi Input Client",
             unsigned int queueSizeLimit = 100 );
 
-  RtMidiIn(RtMidiIn&& other) noexcept : RtMidi(std::move(other)) { }
+  RtMidiIn(RtMidiIn&& other) RTMIDI_NOEXCEPT : RtMidi(std::move(other)) { }
 
   //! If a MIDI connection is still open, it will be closed by the destructor.
   ~RtMidiIn ( void ) throw();
@@ -410,7 +416,7 @@ class RTMIDI_DLL_PUBLIC RtMidiOut : public RtMidi
   RtMidiOut( RtMidi::Api api=UNSPECIFIED,
              const std::string& clientName = "RtMidi Output Client" );
 
-  RtMidiOut(RtMidiOut&& other) noexcept : RtMidi(std::move(other)) { }
+  RtMidiOut(RtMidiOut&& other) RTMIDI_NOEXCEPT : RtMidi(std::move(other)) { }
 
   //! The destructor closes any open MIDI connections.
   ~RtMidiOut( void ) throw();


### PR DESCRIPTION
Make `RtMidi`, `RtMidiIn`, and `RtMidiOut` moveable, but non-copyable.

This was branched off of #237 -- Make RtMidi non-copyable. 

Essentially I was trying to make a resizable `std::vector<RtMidiIn>`, but it didn't work as expected. Resizing `std::vector` requires copying or moving data when the internal array resizes, but `RtMidi`'s copy was not well-defined and ultimately caused the new RtMidi instances to have a dangling pointer to deleted memory (`rtapi_`).

Copying an `RtMidi` doesn't make sense at the moment because it will always destroy its `rtapi_` when it destructs, so two `RtMidi` instances sharing their `rtapi_` will always result in an error. For this reason I made it non-copyable.

It was pointed out in #237 that making `RtMidi` moveable could still allow it to be used with `std::vector`. It also shouldn't cause any error conditions. So I implemented a move constructor for `RtMidi` and its derived classes.

Tested and working in Windows.