### PR TITLE
Surrounded all std::err calls regarding message queue limit reached with debug check to prevent flooding of output console

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -829,8 +829,12 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
         }
         else {
           // As long as we haven't reached our queue size limit, push the message.
-          if ( !data->queue.push( message ) )
+          if (!data->queue.push(message))
+          {
+#if defined(__RTMIDI_DEBUG__)
             std::cerr << "\nMidiInCore: message queue limit reached!!\n\n";
+#endif
+          }
         }
         message.bytes.clear();
       }
@@ -888,8 +892,12 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
             }
             else {
               // As long as we haven't reached our queue size limit, push the message.
-              if ( !data->queue.push( message ) )
+              if (!data->queue.push(message))
+              {
+#if defined(__RTMIDI_DEBUG__)
                 std::cerr << "\nMidiInCore: message queue limit reached!!\n\n";
+#endif
+              }
             }
             message.bytes.clear();
           }
@@ -1725,8 +1733,12 @@ static void *alsaMidiHandler( void *ptr )
     }
     else {
       // As long as we haven't reached our queue size limit, push the message.
-      if ( !data->queue.push( message ) )
+      if (!data->queue.push(message))
+      {
+#if defined(__RTMIDI_DEBUG__)
         std::cerr << "\nMidiInAlsa: message queue limit reached!!\n\n";
+#endif
+      }
     }
   }
 
@@ -2529,8 +2541,12 @@ static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
   }
   else {
     // As long as we haven't reached our queue size limit, push the message.
-    if ( !data->queue.push( apiData->message ) )
+    if (!data->queue.push(apiData->message))
+    {
+#if defined(__RTMIDI_DEBUG__)
       std::cerr << "\nMidiInWinMM: message queue limit reached!!\n\n";
+#endif
+    }
   }
 
   // Clear the vector for the next input message.
@@ -3070,8 +3086,12 @@ static int jackProcessIn( jack_nframes_t nframes, void *arg )
       }
       else {
         // As long as we haven't reached our queue size limit, push the message.
-        if ( !rtData->queue.push( message ) )
+        if (!rtData->queue.push(message))
+        {
+#if defined(__RTMIDI_DEBUG__)
           std::cerr << "\nMidiInJack: message queue limit reached!!\n\n";
+#endif
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #236 

Surrounded all std::err calls regarding message queue limit reached with a #if defined(__RTMIDI_DEBUG__) in order to prevent console flooding when message queue limit is reached.

I filed this issue a while back and no one responded to me whether I was correct or not in my observations/assumptions so I took matters to my own hands.