### PR TITLE
trim whitespace from endpoint names

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1120,6 +1120,7 @@ CFStringRef EndpointName( MIDIEndpointRef endpoint, bool isExternal )
   // some MIDI devices have a leading space in endpoint name. trim
   CFStringRef space = CFStringCreateWithCString(NULL, " ", kCFStringEncodingUTF8);
   CFStringTrim(result, space);
+  CFRelease(space);
 
   MIDIEntityRef entity = 0;
   MIDIEndpointGetEntity( endpoint, &entity );

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1117,6 +1117,10 @@ CFStringRef EndpointName( MIDIEndpointRef endpoint, bool isExternal )
     CFRelease( str );
   }
 
+  // some MIDI devices have a leading space in endpoint name. trim
+  CFStringRef space = CFStringCreateWithCString(NULL, " ", kCFStringEncodingUTF8);
+  CFStringTrim(result, space);
+
   MIDIEntityRef entity = 0;
   MIDIEndpointGetEntity( endpoint, &entity );
   if ( entity == 0 )


### PR DESCRIPTION
The endpoint names of some devices (Impulse25 in my case) have a leading whitespace. 

The extra whitespace causes the the `if` statement at [L1161](https://github.com/thestk/rtmidi/blob/master/RtMidi.cpp#L1161) to evaluate to `true`, whereas it should evaluate to `false`. This causes the name of its ports to be "Impulse__Impulse_" and "Impulse__Impulse_MIDI_In_" (whitespaces replaced with underscores for visibility).

Fixed using CFStringTrim.

Thank you for all of your work in making rtmidi available!