### PR TITLE
Fix RtMidiConfig.cmake install location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,7 +248,7 @@ endif()
 file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/RtMidiConfig.cmake "include(\${CMAKE_CURRENT_LIST_DIR}/RtMidiTargets.cmake)")
 
 # Install CMake configuration export file.
-install(FILES ${CMAKE_BINARY_DIR}/RtMidiConfig.cmake
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/RtMidiConfig.cmake
         DESTINATION ${RTMIDI_CMAKE_DESTINATION})
 
 # Export library target (build-tree).


### PR DESCRIPTION
Regarding my work on the RtMidi conan recipe mentioned [here](https://github.com/thestk/rtmidi/issues/251), I needed to apply this patch which shouldn't have any consequences and would avoid having to patch every next release of the RtMidi recipe:

https://github.com/conan-io/conan-center-index/blob/923cf523d50b1b072ffe3104c1eba83b2649d583/recipes/rtmidi/all/patches/4.0.0-0002-rtmidiconfig-install-location-da51f21.patch

Would you mind mergin this?
