### PR TITLE
Change "Requires:" to "Requires.private:" in rtmidi.pc

### DIFF
--- a/rtmidi.pc.in
+++ b/rtmidi.pc.in
@@ -6,7 +6,7 @@ includedir=${prefix}/include/rtmidi
 Name: librtmidi
 Description: RtMidi - a set of C++ classes that provide a common API for realtime MIDI input/output
 Version: @PACKAGE_VERSION@
-Requires: @req@
+Requires.private: @req@
 Libs: -L${libdir} -lrtmidi
 Libs.private: -lpthread
 Cflags: -pthread -I${includedir} @api@


### PR DESCRIPTION
This makes it possible to get the appropriate requirements if you pass `--static` to
pkg-config, but otherwise direct links to the API libs are not necessary when dynamically
linking.

Closes #204.