### PR TITLE
Jack: Check port name against port name size on failure to open.

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -3188,6 +3188,8 @@ void MidiInJack :: openPort( unsigned int portNumber, const std::string &portNam
 
   if ( data->port == NULL ) {
     errorString_ = "MidiInJack::openPort: JACK error creating port";
+    if (portName.size() >= (size_t)jack_port_name_size())
+        errorString_ += " (port name too long?)";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
   }
@@ -3210,6 +3212,8 @@ void MidiInJack :: openVirtualPort( const std::string &portName )
 
   if ( data->port == NULL ) {
     errorString_ = "MidiInJack::openVirtualPort: JACK error creating virtual port";
+    if (portName.size() >= (size_t)jack_port_name_size())
+        errorString_ += " (port name too long?)";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
   }
 }
@@ -3406,6 +3410,8 @@ void MidiOutJack :: openPort( unsigned int portNumber, const std::string &portNa
 
   if ( data->port == NULL ) {
     errorString_ = "MidiOutJack::openPort: JACK error creating port";
+    if (portName.size() >= (size_t)jack_port_name_size())
+        errorString_ += " (port name too long?)";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
   }
@@ -3428,6 +3434,8 @@ void MidiOutJack :: openVirtualPort( const std::string &portName )
 
   if ( data->port == NULL ) {
     errorString_ = "MidiOutJack::openVirtualPort: JACK error creating virtual port";
+    if (portName.size() >= (size_t)jack_port_name_size())
+        errorString_ += " (port name too long?)";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
   }
 }


### PR DESCRIPTION
This is just a simple approach to the issue raised in #226.  I looked for a more general way to get error messages from Jack but it seems like you have to register one global error handler -- and I'm not sure the warning would help for the issue.  So, this just seems like the simplest approach for this particular situation, just explicitly checking the length of the string against `jack_port_name_size()` and issuing an extra bit of information.