### PR TITLE
WinMM: Disable midiOutReset.

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -2897,7 +2897,10 @@ void MidiOutWinMM :: closePort( void )
 {
   if ( connected_ ) {
     WinMidiData *data = static_cast<WinMidiData *> (apiData_);
-    midiOutReset( data->outHandle );
+    // Disabled because midiOutReset triggers 0x7b (if any note was ON) and 0x79 "Reset All
+    // Controllers" (to all 16 channels) CC messages which is undesirable (see issue #222)
+    // midiOutReset( data->outHandle );
+
     midiOutClose( data->outHandle );
     data->outHandle = 0;
     connected_ = false;


### PR DESCRIPTION
This disables the call to midiOutReset.

The idea in #222 was to make it optional but it's not clear what the best way to accomplish that is.

In the meantime it seems pretty obvious that sending unsolicited MIDI messages is undesirable?