### PR TITLE
RtMidi.cpp: include TargetConditionals.h on Apple platforms

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -39,6 +39,9 @@
 
 #include "RtMidi.h"
 #include <sstream>
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
 
 #if (TARGET_OS_IPHONE == 1)
 


### PR DESCRIPTION
Fixes errors like
```
source/RtMidi.cpp:44:7: error: 'TARGET_OS_IPHONE' is not defined, evaluates to 0 [-Werror,-Wundef-prefix=TARGET_OS_]
  #if TARGET_OS_IPHONE
      ^
1 error generated.
```