### PR TITLE
Use posix sched_yield instead of pthread_yield

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -3092,6 +3092,7 @@ void MidiOutWinMM :: sendMessage( const unsigned char *message, size_t size )
 #include <jack/midiport.h>
 #include <jack/ringbuffer.h>
 #include <pthread.h>
+#include <sched.h>
 #ifdef HAVE_SEMAPHORE
   #include <semaphore.h>
 #endif
@@ -3608,7 +3609,7 @@ void MidiOutJack :: sendMessage( const unsigned char *message, size_t size )
       return;
 
   while ( jack_ringbuffer_write_space(data->buff) < sizeof(nBytes) + size )
-      pthread_yield();
+      sched_yield();
 
   // Write full message to buffer
   jack_ringbuffer_write( data->buff, ( char * ) &nBytes, sizeof( nBytes ) );


### PR DESCRIPTION
Use posix sched_yield instead of pthread_yield.
pthread_yield is linux specific sched_yield is
a standard posix function. pthread_yield on linux
is implemented using sched_yield.
This makes the jack plugin work on other
platforms than linux. Fixes build of Jack on NetBSD.