### PR TITLE
[emscripten] fix getPortName() runtime signature mismatch.

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -3723,7 +3723,7 @@ std::string WebMidiAccessShim::getPortName( unsigned int portNumber, bool isInpu
     var ret = _malloc(length);
     stringToUTF8(port.name, ret, length);
     return ret;
-  }, portNumber, isInput, &ret );
+  }, portNumber, isInput);
   if (ret == nullptr)
       return "";
   std::string s = ret;


### PR DESCRIPTION
Earlier versions of emscripten did not complain about this extra argument
but it became more strict and correctly reports the mismatch.