### PR TITLE
Replaced deprecated pthread_yield with sched_yield

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -3608,7 +3608,7 @@ void MidiOutJack :: sendMessage( const unsigned char *message, size_t size )
       return;
 
   while ( jack_ringbuffer_write_space(data->buff) < sizeof(nBytes) + size )
-      pthread_yield();
+      sched_yield();
 
   // Write full message to buffer
   jack_ringbuffer_write( data->buff, ( char * ) &nBytes, sizeof( nBytes ) );


### PR DESCRIPTION
After the change https://github.com/thestk/rtmidi/commit/a4c7e13f9eac37ca24bd7bcec7709a52b5f6113c

RtMidi.cpp started using the function `pthread_yield`. But this function is deprecated https://lists.gnu.org/archive/html/info-gnu/2021-08/msg00001.html

Moreover, mingw doesn't provide this function, so rtmidi 5.0.0 cann't be compiled with mingw.

This PR replaces using the deprecated `pthread_yield` with `sched_yield` as it is recommented in the gnu changelist mentioned above.

After this PR RtMidi.cpp can be compiled with  both gcc and mingw-w64