### PR TITLE
[cmake] Fix use of GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,9 @@ set_target_properties(rtmidi PROPERTIES
   SOVERSION ${SO_VER}
   VERSION ${FULL_VER})
 
+# Set standard installation directories.
+include(GNUInstallDirs)
+
 # Set include paths, populate target interface.
 target_include_directories(rtmidi PRIVATE ${INCDIRS}
                                   PUBLIC
@@ -198,9 +201,6 @@ target_compile_definitions(rtmidi PRIVATE ${API_DEFS})
 target_compile_definitions(rtmidi PRIVATE RTMIDI_EXPORT)
 target_link_libraries(rtmidi PUBLIC ${PUBLICLINKLIBS} 
                              PRIVATE ${LINKLIBS})
-
-# Set standard installation directories.
-include(GNUInstallDirs)
 
 # Add tests if requested.
 option(RTMIDI_BUILD_TESTING "Build test programs" ON)


### PR DESCRIPTION
I noticed behavior similar to https://github.com/PortAudio/portaudio/issues/689.
When running cmake only once before install, the public headers would not get added to the ```RtMidi::rtmidi``` target. Running cmake again adds the headers. It seems that is caused by using a feature of GNUInstallDirs (which I am not familiar with) before including it. The fix proposed in https://github.com/PortAudio/portaudio/pull/690 solves the problem.