### PR TITLE
Updating contrib/go to work with v5.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@
 *.exe
 *.out
 *.app
+
+# Go
+!/contrib/go/rtmidi/go.mod

--- a/contrib/go/rtmidi/go.mod
+++ b/contrib/go/rtmidi/go.mod
@@ -1,0 +1,3 @@
+module github.com/thestk/rtmidi/contrib/go/rtmidi
+
+go 1.14

--- a/contrib/go/rtmidi/rtmidi.go
+++ b/contrib/go/rtmidi/rtmidi.go
@@ -50,6 +50,7 @@ const (
 	APIDummy API = C.RTMIDI_API_RTMIDI_DUMMY
 )
 
+// Format an API as a string
 func (api API) String() string {
 	switch api {
 	case APIUnspecified:
@@ -121,6 +122,7 @@ type midi struct {
 	midi C.RtMidiPtr
 }
 
+// Open a MIDI input connection given by enumeration number.
 func (m *midi) OpenPort(port int, name string) error {
 	p := C.CString(name)
 	defer C.free(unsafe.Pointer(p))
@@ -131,6 +133,8 @@ func (m *midi) OpenPort(port int, name string) error {
 	return nil
 }
 
+// Create a virtual input port, with optional name, to allow software connections
+// (OS X, JACK and ALSA only).
 func (m *midi) OpenVirtualPort(name string) error {
 	p := C.CString(name)
 	defer C.free(unsafe.Pointer(p))
@@ -141,6 +145,7 @@ func (m *midi) OpenVirtualPort(name string) error {
 	return nil
 }
 
+// Return a string identifier for the specified MIDI input port number.
 func (m *midi) PortName(port int) (string, error) {
 	p := C.rtmidi_get_port_name(m.midi, C.uint(port))
 	if !m.midi.ok {
@@ -150,6 +155,7 @@ func (m *midi) PortName(port int) (string, error) {
 	return C.GoString(p), nil
 }
 
+// Return the number of available MIDI input ports.
 func (m *midi) PortCount() (int, error) {
 	n := C.rtmidi_get_port_count(m.midi)
 	if !m.midi.ok {
@@ -158,6 +164,7 @@ func (m *midi) PortCount() (int, error) {
 	return int(n), nil
 }
 
+// Close an open MIDI connection.
 func (m *midi) Close() error {
 	C.rtmidi_close_port(C.RtMidiPtr(m.midi))
 	if !m.midi.ok {
@@ -177,7 +184,7 @@ type midiOut struct {
 	out C.RtMidiOutPtr
 }
 
-// NewMIDIInDefault opens a default MIDIIn port.
+// Open a default MIDIIn port.
 func NewMIDIInDefault() (MIDIIn, error) {
 	in := C.rtmidi_in_create_default()
 	if !in.ok {
@@ -187,7 +194,7 @@ func NewMIDIInDefault() (MIDIIn, error) {
 	return &midiIn{in: in, midi: midi{midi: C.RtMidiPtr(in)}}, nil
 }
 
-// NewMIDIIn opens a single MIDIIn port using the given API. One can provide a
+// Open a single MIDIIn port using the given API. One can provide a
 // custom port name and a desired queue size for the incomming MIDI messages.
 func NewMIDIIn(api API, name string, queueSize int) (MIDIIn, error) {
 	p := C.CString(name)
@@ -200,6 +207,7 @@ func NewMIDIIn(api API, name string, queueSize int) (MIDIIn, error) {
 	return &midiIn{in: in, midi: midi{midi: C.RtMidiPtr(in)}}, nil
 }
 
+// Return the MIDI API specifier for the current instance of RtMidiIn.
 func (m *midiIn) API() (API, error) {
 	api := C.rtmidi_in_get_current_api(m.in)
 	if !m.in.ok {
@@ -208,6 +216,7 @@ func (m *midiIn) API() (API, error) {
 	return API(api), nil
 }
 
+// Close an open MIDI connection (if one exists).
 func (m *midiIn) Close() error {
 	unregisterMIDIIn(m)
 	if err := m.midi.Close(); err != nil {
@@ -217,6 +226,13 @@ func (m *midiIn) Close() error {
 	return nil
 }
 
+// Specify whether certain MIDI message types should be queued or ignored during input.
+//
+// By default, MIDI timing and active sensing messages are ignored
+// during message input because of their relative high data rates.
+// MIDI sysex messages are ignored by default as well.  Variable
+// values of "true" imply that the respective message type will be
+// ignored.
 func (m *midiIn) IgnoreTypes(midiSysex bool, midiTime bool, midiSense bool) error {
 	C.rtmidi_in_ignore_types(m.in, C._Bool(midiSysex), C._Bool(midiTime), C._Bool(midiSense))
 	if !m.in.ok {
@@ -265,6 +281,7 @@ func goMIDIInCallback(ts C.double, msg *C.uchar, msgsz C.size_t, arg unsafe.Poin
 	m.cb(m, C.GoBytes(unsafe.Pointer(msg), C.int(msgsz)), float64(ts))
 }
 
+// Set a callback function to be invoked for incoming MIDI messages.
 func (m *midiIn) SetCallback(cb func(MIDIIn, []byte, float64)) error {
 	k := registerMIDIIn(m)
 	m.cb = cb
@@ -275,6 +292,7 @@ func (m *midiIn) SetCallback(cb func(MIDIIn, []byte, float64)) error {
 	return nil
 }
 
+// Cancel use of the current callback function (if one exists).
 func (m *midiIn) CancelCallback() error {
 	unregisterMIDIIn(m)
 	C.rtmidi_in_cancel_callback(m.in)
@@ -284,6 +302,10 @@ func (m *midiIn) CancelCallback() error {
 	return nil
 }
 
+// Fill a byte buffer with the next available MIDI message in the input queue
+// and return the event delta-time in seconds.
+//
+// This function returns immediately whether a new message is available or not.
 func (m *midiIn) Message() ([]byte, float64, error) {
 	msg := make([]C.uchar, 64*1024, 64*1024)
 	sz := C.size_t(len(msg))
@@ -302,7 +324,7 @@ func (m *midiIn) Destroy() {
 	C.rtmidi_in_free(m.in)
 }
 
-// NewMIDIOutDefault opens a default MIDIOut port.
+// Open a default MIDIOut port.
 func NewMIDIOutDefault() (MIDIOut, error) {
 	out := C.rtmidi_out_create_default()
 	if !out.ok {
@@ -312,7 +334,7 @@ func NewMIDIOutDefault() (MIDIOut, error) {
 	return &midiOut{out: out, midi: midi{midi: C.RtMidiPtr(out)}}, nil
 }
 
-// NewMIDIOut opens a single MIDIIn port using the given API with the given port name.
+// Open a single MIDIIn port using the given API with the given port name.
 func NewMIDIOut(api API, name string) (MIDIOut, error) {
 	p := C.CString(name)
 	defer C.free(unsafe.Pointer(p))
@@ -324,6 +346,7 @@ func NewMIDIOut(api API, name string) (MIDIOut, error) {
 	return &midiOut{out: out, midi: midi{midi: C.RtMidiPtr(out)}}, nil
 }
 
+// Return the MIDI API specifier for the current instance of RtMidiOut.
 func (m *midiOut) API() (API, error) {
 	api := C.rtmidi_out_get_current_api(m.out)
 	if !m.out.ok {
@@ -332,6 +355,7 @@ func (m *midiOut) API() (API, error) {
 	return API(api), nil
 }
 
+// Close an open MIDI connection.
 func (m *midiOut) Close() error {
 	if err := m.midi.Close(); err != nil {
 		return err
@@ -340,6 +364,7 @@ func (m *midiOut) Close() error {
 	return nil
 }
 
+// Immediately send a single message out an open MIDI output port.
 func (m *midiOut) SendMessage(b []byte) error {
 	p := C.CBytes(b)
 	defer C.free(unsafe.Pointer(p))

--- a/contrib/go/rtmidi/rtmidi.go
+++ b/contrib/go/rtmidi/rtmidi.go
@@ -162,7 +162,7 @@ func (m *midi) PortName(port int) (string, error) {
 		return "", errors.New(C.GoString(m.midi.msg))
 	}
 
-	return string(bufOut), nil
+	return string(bufOut[0 : bufLen-1]), nil
 }
 
 // Return the number of available MIDI input ports.

--- a/contrib/go/rtmidi/rtmidi.go
+++ b/contrib/go/rtmidi/rtmidi.go
@@ -1,7 +1,7 @@
 package rtmidi
 
 /*
-#cgo CXXFLAGS: -g
+#cgo CXXFLAGS: -g -std=c++11
 #cgo LDFLAGS: -g
 
 #cgo linux CXXFLAGS: -D__LINUX_ALSA__

--- a/contrib/go/rtmidi/rtmidi.go
+++ b/contrib/go/rtmidi/rtmidi.go
@@ -147,12 +147,22 @@ func (m *midi) OpenVirtualPort(name string) error {
 
 // Return a string identifier for the specified MIDI input port number.
 func (m *midi) PortName(port int) (string, error) {
-	p := C.rtmidi_get_port_name(m.midi, C.uint(port))
+	bufLen := C.int(0)
+
+	C.rtmidi_get_port_name(m.midi, C.uint(port), nil, &bufLen)
 	if !m.midi.ok {
 		return "", errors.New(C.GoString(m.midi.msg))
 	}
-	defer C.free(unsafe.Pointer(p))
-	return C.GoString(p), nil
+
+	bufOut := make([]byte, int(bufLen))
+	p := (*C.char)(unsafe.Pointer(&bufOut[0]))
+
+	C.rtmidi_get_port_name(m.midi, C.uint(port), p, &bufLen)
+	if !m.midi.ok {
+		return "", errors.New(C.GoString(m.midi.msg))
+	}
+
+	return string(bufOut), nil
 }
 
 // Return the number of available MIDI input ports.

--- a/contrib/go/rtmidi/rtmidi.go
+++ b/contrib/go/rtmidi/rtmidi.go
@@ -154,6 +154,10 @@ func (m *midi) PortName(port int) (string, error) {
 		return "", errors.New(C.GoString(m.midi.msg))
 	}
 
+	if bufLen < 1 {
+		return "", nil
+	}
+
 	bufOut := make([]byte, int(bufLen))
 	p := (*C.char)(unsafe.Pointer(&bufOut[0]))
 

--- a/contrib/go/rtmidi/rtmidi.go
+++ b/contrib/go/rtmidi/rtmidi.go
@@ -39,15 +39,15 @@ const (
 	// APIUnspecified searches for a working compiled API.
 	APIUnspecified API = C.RTMIDI_API_UNSPECIFIED
 	// APIMacOSXCore uses Macintosh OS-X CoreMIDI API.
-	APIMacOSXCore = C.RTMIDI_API_MACOSX_CORE
+	APIMacOSXCore API = C.RTMIDI_API_MACOSX_CORE
 	// APILinuxALSA uses the Advanced Linux Sound Architecture API.
-	APILinuxALSA = C.RTMIDI_API_LINUX_ALSA
+	APILinuxALSA API = C.RTMIDI_API_LINUX_ALSA
 	// APIUnixJack uses the JACK Low-Latency MIDI Server API.
-	APIUnixJack = C.RTMIDI_API_UNIX_JACK
+	APIUnixJack API = C.RTMIDI_API_UNIX_JACK
 	// APIWindowsMM uses the Microsoft Multimedia MIDI API.
-	APIWindowsMM = C.RTMIDI_API_WINDOWS_MM
+	APIWindowsMM API = C.RTMIDI_API_WINDOWS_MM
 	// APIDummy is a compilable but non-functional API.
-	APIDummy = C.RTMIDI_API_RTMIDI_DUMMY
+	APIDummy API = C.RTMIDI_API_RTMIDI_DUMMY
 )
 
 func (api API) String() string {

--- a/contrib/go/rtmidi/rtmidi_stub.cpp
+++ b/contrib/go/rtmidi/rtmidi_stub.cpp
@@ -1,4 +1,5 @@
 #include "../../../RtMidi.h"
 
+#define RTMIDI_SOURCE_INCLUDED
 #include "../../../RtMidi.cpp"
 #include "../../../rtmidi_c.cpp"

--- a/rtmidi_c.cpp
+++ b/rtmidi_c.cpp
@@ -42,7 +42,9 @@ class CallbackProxyUserData
   void *user_data;
 };
 
-extern "C" const enum RtMidiApi rtmidi_compiled_apis[]; // casting from RtMidi::Api[]
+#ifndef RTMIDI_SOURCE_INCLUDED
+    extern "C" const enum RtMidiApi rtmidi_compiled_apis[]; // casting from RtMidi::Api[]
+#endif
 extern "C" const unsigned int rtmidi_num_compiled_apis;
 
 /* RtMidi API */

--- a/rtmidi_c.cpp
+++ b/rtmidi_c.cpp
@@ -5,12 +5,12 @@
 
 /* Compile-time assertions that will break if the enums are changed in
  * the future without synchronizing them properly.  If you get (g++)
- * "error: ‘StaticAssert<b>::StaticAssert() [with bool b = false]’ is
- * private within this context", it means enums are not aligned. */
-template<bool b> class StaticAssert { private: StaticAssert() {} };
-template<> class StaticAssert<true>{ public: StaticAssert() {} };
-#define ENUM_EQUAL(x,y) StaticAssert<(int)x==(int)y>()
-class StaticAssertions { StaticAssertions() {
+ * "error: ‘StaticEnumAssert<b>::StaticEnumAssert() [with bool b = false]’
+ * is private within this context", it means enums are not aligned. */
+template<bool b> class StaticEnumAssert { private: StaticEnumAssert() {} };
+template<> class StaticEnumAssert<true>{ public: StaticEnumAssert() {} };
+#define ENUM_EQUAL(x,y) StaticEnumAssert<(int)x==(int)y>()
+class StaticEnumAssertions { StaticEnumAssertions() {
     ENUM_EQUAL( RTMIDI_API_UNSPECIFIED,     RtMidi::UNSPECIFIED );
     ENUM_EQUAL( RTMIDI_API_MACOSX_CORE,     RtMidi::MACOSX_CORE );
     ENUM_EQUAL( RTMIDI_API_LINUX_ALSA,      RtMidi::LINUX_ALSA );


### PR DESCRIPTION
Trying to rebuild a Go project with the current release, I noticed that _contrib/go/rtmidi_ hasn't kept up with the C++/C library, and wanted to offer some changes to get it working again.

* The API constants aren't being defined as the API type.
* The signature for [rtmidi_get_port_name](https://github.com/thestk/rtmidi/blob/master/rtmidi_c.cpp#L135) changed in commit f922c14.
* A `-std=c++11` flag has been required to build since 3650105.
* Go can't easily build or link with object files elsewhere in the repo, so it `#include`s both _RtMidi.cpp_ and _rtmidi_c.cpp_ and compiles them as a single source file. Unfortunately, there are two symbol collisions introduced after the Go module was committed that prevent this. To remedy this, I propose:

    * Renaming the identical [StaticAssert](https://github.com/thestk/rtmidi/blob/master/rtmidi_c.cpp#L10) template class in _rtmidi_c.cpp_ to `StaticEnumAssert`.
    * Hiding the redeclaration of [rtmidi_compiled_apis](https://github.com/thestk/rtmidi/blob/master/rtmidi_c.cpp#L45) behind a C-def. There may be a more elegant way to do it, but I imagine it would require making changes in more places, including the test case.

* Adding a _go.mod_ file.

After these changes, `go test` and `go build` work in the _contrib/go/rtmidi_ directory [without check issues](https://github.com/mattrtaylor/rtmidi/actions/runs/2164844483) for the platforms in the CI. I'll submit a separate, stacked pull request with a CI job that tests the Go module should that also be of interest.