### PR TITLE
Make sure to set the connected_ state also on web

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -3782,6 +3782,7 @@ void MidiInWeb::openPort( unsigned int portNumber, const std::string &portName )
     };
   }, portNumber, &inputData_ );
   open_port_number = portNumber;
+  connected_ = true;
 }
 
 void MidiInWeb::openVirtualPort( const std::string &portName )
@@ -3807,6 +3808,7 @@ void MidiInWeb::closePort( void )
     input.onmidimessage = null;
   }, open_port_number );
   open_port_number = -1;
+  connected_ = false;
 }
 
 void MidiInWeb::setClientName( const std::string &clientName )
@@ -3866,6 +3868,7 @@ void MidiOutWeb::openPort( unsigned int portNumber, const std::string &portName 
   // In Web MIDI API world, there is no step to open a port.
 
   open_port_number = portNumber;
+  connected_ = true;
 }
 
 void MidiOutWeb::openVirtualPort( const std::string &portName )
@@ -3880,6 +3883,7 @@ void MidiOutWeb::closePort( void )
 {
   // there is really nothing to do for output at JS side.
   open_port_number = -1;
+  connected_ = false;
 }
 
 void MidiOutWeb::setClientName( const std::string &clientName )


### PR DESCRIPTION
The `isPortOpen()` function always returns false on web builds. This is to some extent expected as one of the code comments read "In Web MIDI API world, there is no step to open a port", but from an API consistency standpoint it's not so good, especially when working on cross platform code built on top of RtMidi.

In this pull request I set the `connected_` flag when calling `openPort()` and `closePort()` also on the web target of RtMidi.