### PR TITLE
Keep compile flags private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,19 +46,6 @@ endif()
 option(RTMIDI_API_WINMM "Compile with WINMM support." ${WIN32})
 option(RTMIDI_API_CORE "Compile with CoreMIDI support." ${APPLE})
 
-# Add -Wall if possible
-if (CMAKE_COMPILER_IS_GNUCXX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-endif (CMAKE_COMPILER_IS_GNUCXX)
-
-# Add debug flags
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  add_definitions(-D__RTMIDI_DEBUG__)
-  if (CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-  endif (CMAKE_COMPILER_IS_GNUCXX)
-endif ()
-
 # Read libtool version info from configure.ac
 set(R "m4_define\\(\\[lt_([a-z]+)\\], ([0-9]+)\\)")
 file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/configure.ac" CONFIGAC
@@ -154,7 +141,7 @@ if(RTMIDI_API_CORE)
 endif()
 
 # pthread
-if (NEED_PTHREAD)
+if(NEED_PTHREAD)
   find_package(Threads REQUIRED
     CMAKE_THREAD_PREFER_PTHREAD
     THREADS_PREFER_PTHREAD_FLAG)
@@ -167,14 +154,14 @@ set(LIB_TARGETS)
 
 # Use RTMIDI_BUILD_SHARED_LIBS / RTMIDI_BUILD_STATIC_LIBS if they
 # are defined, otherwise default to standard BUILD_SHARED_LIBS.
-if (DEFINED RTMIDI_BUILD_SHARED_LIBS AND NOT RTMIDI_BUILD_SHARED_LIBS STREQUAL "")
-  if (RTMIDI_BUILD_SHARED_LIBS)
+if(DEFINED RTMIDI_BUILD_SHARED_LIBS AND NOT RTMIDI_BUILD_SHARED_LIBS STREQUAL "")
+  if(RTMIDI_BUILD_SHARED_LIBS)
     add_library(rtmidi SHARED ${rtmidi_SOURCES})
   else()
     add_library(rtmidi STATIC ${rtmidi_SOURCES})
   endif()
-elseif (DEFINED RTMIDI_BUILD_STATIC_LIBS AND NOT RTMIDI_BUILD_STATIC_LIBS STREQUAL "")
-  if (RTMIDI_BUILD_STATIC_LIBS)
+elseif(DEFINED RTMIDI_BUILD_STATIC_LIBS AND NOT RTMIDI_BUILD_STATIC_LIBS STREQUAL "")
+  if(RTMIDI_BUILD_STATIC_LIBS)
     add_library(rtmidi STATIC ${rtmidi_SOURCES})
   else()
     add_library(rtmidi SHARED ${rtmidi_SOURCES})
@@ -183,6 +170,19 @@ else()
   add_library(rtmidi ${rtmidi_SOURCES})
 endif()
 list(APPEND LIB_TARGETS rtmidi)
+
+# Add -Wall if possible
+if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+  target_compile_options(rtmidi PRIVATE -Wall)
+endif()
+
+# Add debug flags
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  add_definitions(-D__RTMIDI_DEBUG__)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+    target_compile_options(rtmidi PRIVATE -Werror)
+  endif()
+endif()
 
 # Add headers destination for install rule.
 set_property(TARGET rtmidi PROPERTY PUBLIC_HEADER RtMidi.h rtmidi_c.h)
@@ -202,7 +202,7 @@ target_include_directories(rtmidi PRIVATE ${INCDIRS}
 # Set compile-time definitions
 target_compile_definitions(rtmidi PRIVATE ${API_DEFS})
 target_compile_definitions(rtmidi PRIVATE RTMIDI_EXPORT)
-target_link_libraries(rtmidi PUBLIC ${PUBLICLINKLIBS} 
+target_link_libraries(rtmidi PUBLIC ${PUBLICLINKLIBS}
                              PRIVATE ${LINKLIBS})
 
 # Add tests if requested.
@@ -210,7 +210,7 @@ option(RTMIDI_BUILD_TESTING "Build test programs" ON)
 if (NOT DEFINED RTMIDI_BUILD_TESTING OR RTMIDI_BUILD_TESTING STREQUAL "")
   set(RTMIDI_BUILD_TESTING ${BUILD_TESTING})
 endif()
-if (RTMIDI_BUILD_TESTING)
+if(RTMIDI_BUILD_TESTING)
   include(CTest)
   add_executable(cmidiin    tests/cmidiin.cpp)
   add_executable(midiclock  tests/midiclock.cpp)
@@ -291,14 +291,14 @@ write_basic_package_version_file(
 string(REPLACE ";" "\n" package_dependencies "${PACKAGE_DEPENDENCIES}")
 
 # Write cmake package config file
-configure_package_config_file (
+configure_package_config_file(
     cmake/rtmidi-config.cmake.in
     rtmidi-config.cmake
     INSTALL_DESTINATION "${RTMIDI_CMAKE_DESTINATION}"
 )
 
 # Install package files
-install (
+install(
     FILES
         "${CMAKE_CURRENT_BINARY_DIR}/rtmidi-config.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/rtmidi-config-version.cmake"


### PR DESCRIPTION
Hi! I used rtmidi with vcpkg and [ran into problems](https://github.com/microsoft/vcpkg/issues/25279) with compiling it with `CMAKE_BUILD_TYPE debug`. I'm not sure if this pull request fixes the problem, but if I understand it right then this at least doesn't propagate Werror to projects that add rtmidi as a dependency.

Also `CMAKE_COMPILER_IS_GNUCXX` is deprecated according to CMake docs, so I replaced it with what was written there.