### PR TITLE
Fix typos

### DIFF
--- a/RtMidi.h
+++ b/RtMidi.h
@@ -86,12 +86,12 @@ class RTMIDI_DLL_PUBLIC RtMidiError : public std::exception
     UNSPECIFIED,       /*!< The default, unspecified error type. */
     NO_DEVICES_FOUND,  /*!< No devices found on system. */
     INVALID_DEVICE,    /*!< An invalid device ID was specified. */
-    MEMORY_ERROR,      /*!< An error occured during memory allocation. */
+    MEMORY_ERROR,      /*!< An error occurred during memory allocation. */
     INVALID_PARAMETER, /*!< An invalid parameter was specified to a function. */
     INVALID_USE,       /*!< The function was called incorrectly. */
-    DRIVER_ERROR,      /*!< A system driver error occured. */
-    SYSTEM_ERROR,      /*!< A system error occured. */
-    THREAD_ERROR       /*!< A thread error occured. */
+    DRIVER_ERROR,      /*!< A system driver error occurred. */
+    SYSTEM_ERROR,      /*!< A system error occurred. */
+    THREAD_ERROR       /*!< A thread error occurred. */
   };
 
   //! The constructor.
@@ -206,9 +206,9 @@ class RTMIDI_DLL_PUBLIC RtMidi
   */
   virtual bool isPortOpen( void ) const = 0;
 
-  //! Set an error callback function to be invoked when an error has occured.
+  //! Set an error callback function to be invoked when an error has occurred.
   /*!
-    The callback function will be called whenever an error has occured. It is best
+    The callback function will be called whenever an error has occurred. It is best
     to set the error callback function before opening a port.
   */
   virtual void setErrorCallback( RtMidiErrorCallback errorCallback = NULL, void *userData = 0 ) = 0;
@@ -373,9 +373,9 @@ class RTMIDI_DLL_PUBLIC RtMidiIn : public RtMidi
   */
   double getMessage( std::vector<unsigned char> *message );
 
-  //! Set an error callback function to be invoked when an error has occured.
+  //! Set an error callback function to be invoked when an error has occurred.
   /*!
-    The callback function will be called whenever an error has occured. It is best
+    The callback function will be called whenever an error has occurred. It is best
     to set the error callback function before opening a port.
   */
   virtual void setErrorCallback( RtMidiErrorCallback errorCallback = NULL, void *userData = 0 );
@@ -491,9 +491,9 @@ class RTMIDI_DLL_PUBLIC RtMidiOut : public RtMidi
   */
   void sendMessage( const unsigned char *message, size_t size );
 
-  //! Set an error callback function to be invoked when an error has occured.
+  //! Set an error callback function to be invoked when an error has occurred.
   /*!
-    The callback function will be called whenever an error has occured. It is best
+    The callback function will be called whenever an error has occurred. It is best
     to set the error callback function before opening a port.
   */
   virtual void setErrorCallback( RtMidiErrorCallback errorCallback = NULL, void *userData = 0 );

--- a/contrib/go/rtmidi/rtmidi.go
+++ b/contrib/go/rtmidi/rtmidi.go
@@ -209,7 +209,7 @@ func NewMIDIInDefault() (MIDIIn, error) {
 }
 
 // Open a single MIDIIn port using the given API. One can provide a
-// custom port name and a desired queue size for the incomming MIDI messages.
+// custom port name and a desired queue size for the incoming MIDI messages.
 func NewMIDIIn(api API, name string, queueSize int) (MIDIIn, error) {
 	p := C.CString(name)
 	defer C.free(unsafe.Pointer(p))

--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -44,7 +44,7 @@ struct RtMidiWrapper {
     //! True when the last function call was OK.
     bool  ok;
 
-    //! If an error occured (ok != true), set to an error message.
+    //! If an error occurred (ok != true), set to an error message.
     const char* msg;
 };
 
@@ -75,12 +75,12 @@ enum RtMidiErrorType {
   RTMIDI_ERROR_UNSPECIFIED,       /*!< The default, unspecified error type. */
   RTMIDI_ERROR_NO_DEVICES_FOUND,  /*!< No devices found on system. */
   RTMIDI_ERROR_INVALID_DEVICE,    /*!< An invalid device ID was specified. */
-  RTMIDI_ERROR_MEMORY_ERROR,      /*!< An error occured during memory allocation. */
+  RTMIDI_ERROR_MEMORY_ERROR,      /*!< An error occurred during memory allocation. */
   RTMIDI_ERROR_INVALID_PARAMETER, /*!< An invalid parameter was specified to a function. */
   RTMIDI_ERROR_INVALID_USE,       /*!< The function was called incorrectly. */
-  RTMIDI_ERROR_DRIVER_ERROR,      /*!< A system driver error occured. */
-  RTMIDI_ERROR_SYSTEM_ERROR,      /*!< A system error occured. */
-  RTMIDI_ERROR_THREAD_ERROR       /*!< A thread error occured. */
+  RTMIDI_ERROR_DRIVER_ERROR,      /*!< A system driver error occurred. */
+  RTMIDI_ERROR_SYSTEM_ERROR,      /*!< A system error occurred. */
+  RTMIDI_ERROR_THREAD_ERROR       /*!< A thread error occurred. */
 };
 
 /*! \brief The type of a RtMidi callback function.


### PR DESCRIPTION
Found via `codespell -q 3 -S ./doc/release.txt,./doc/doxygen/Doxyfile.in -L numer,tha,therefor`