### PR TITLE
Realign enum order across C and C++ interfaces

### DIFF
--- a/RtMidi.h
+++ b/RtMidi.h
@@ -142,8 +142,8 @@ class RTMIDI_DLL_PUBLIC RtMidi
     LINUX_ALSA,     /*!< The Advanced Linux Sound Architecture API. */
     UNIX_JACK,      /*!< The JACK Low-Latency MIDI Server API. */
     WINDOWS_MM,     /*!< The Microsoft Multimedia MIDI API. */
-    RTMIDI_DUMMY,   /*!< A compilable but non-functional API. */
     WEB_MIDI_API,   /*!< W3C Web MIDI API. */
+    RTMIDI_DUMMY,   /*!< A compilable but non-functional API. */
     NUM_APIS        /*!< Number of values in this enum. */
   };
 

--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -64,6 +64,7 @@ enum RtMidiApi {
     RTMIDI_API_LINUX_ALSA,     /*!< The Advanced Linux Sound Architecture API. */
     RTMIDI_API_UNIX_JACK,      /*!< The Jack Low-Latency MIDI Server API. */
     RTMIDI_API_WINDOWS_MM,     /*!< The Microsoft Multimedia MIDI API. */
+    RTMIDI_API_WEB_MIDI_API,   /*!< A compilable but non-functional API. */
     RTMIDI_API_RTMIDI_DUMMY,   /*!< A compilable but non-functional API. */
     RTMIDI_API_NUM             /*!< Number of values in this enum. */
 };


### PR DESCRIPTION
It looks like the new Web API didn't make it to the header for the C wrapper. This change adds the value to the C API's enum, and changes the order in the C++ header to align with `rtmidi_api_names` here: https://github.com/thestk/rtmidi/blob/806e18f575b68c23b26f9398e1b6866b335b5308/RtMidi.cpp#L375-L386

(I think pushing the "dummy" interface to the end makes sense...)

Thanks!