### PR TITLE
Add rtmidi_get_version() to C API

### DIFF
--- a/rtmidi_c.cpp
+++ b/rtmidi_c.cpp
@@ -48,6 +48,11 @@ class CallbackProxyUserData
 extern "C" const unsigned int rtmidi_num_compiled_apis;
 
 /* RtMidi API */
+const char* rtmidi_get_version()
+{
+    return RTMIDI_VERSION;
+}
+
 int rtmidi_get_compiled_api (enum RtMidiApi *apis, unsigned int apis_size)
 {
     unsigned num = rtmidi_num_compiled_apis;

--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -97,6 +97,11 @@ typedef void(* RtMidiCCallback) (double timeStamp, const unsigned char* message,
 
 /* RtMidi API */
 
+/*! \brief Return the current RtMidi version.
+ *! See \ref RtMidi::getVersion().
+*/
+RTMIDIAPI const char* rtmidi_get_version();
+
 /*! \brief Determine the available compiled MIDI APIs.
  *
  * If the given `apis` parameter is null, returns the number of available APIs.


### PR DESCRIPTION
I am the maintainer of the [Perl binding to RtMidi](https://metacpan.org/pod/MIDI::RtMidi::FFI), working on an update for RtMidi 5.0.0. I am currently probing characteristics of various C API components to somewhat-heuristically determine the library version, so I think this will be a useful addition for language binding maintainers.

I've found the C API incredibly useful, as C++ isn't a first-class citizen just yet (that is, calling `RtMidi::getVersion` is non-trivial).

The binding is intended to be installable without necessarily requiring a compiler, so the opportunity to simply pull this value from a header during install is not guaranteed.

Thanks!