### PR TITLE
Add a method to reset the ok flag and clear the error message

### DIFF
--- a/rtmidi_c.cpp
+++ b/rtmidi_c.cpp
@@ -94,6 +94,12 @@ void rtmidi_error (MidiApi *api, enum RtMidiErrorType type, const char* errorStr
   api->error ((RtMidiError::Type) type, msg);
 }
 
+void rtmidi_clear_error (RtMidiPtr device)
+{
+    device->ok = true;
+    device->msg = "";
+}
+
 void rtmidi_open_port (RtMidiPtr device, unsigned int portNumber, const char *portName)
 {
     std::string name = portName;
@@ -102,7 +108,7 @@ void rtmidi_open_port (RtMidiPtr device, unsigned int portNumber, const char *po
 
     } catch (const RtMidiError & err) {
         device->ok  = false;
-        device->msg = err.what ();
+        device->msg = strdup (err.what ());
     }
 }
 
@@ -114,7 +120,7 @@ void rtmidi_open_virtual_port (RtMidiPtr device, const char *portName)
 
     } catch (const RtMidiError & err) {
         device->ok  = false;
-        device->msg = err.what ();
+        device->msg = strdup (err.what ());
     }
 
 }
@@ -126,7 +132,7 @@ void rtmidi_close_port (RtMidiPtr device)
 
     } catch (const RtMidiError & err) {
         device->ok  = false;
-        device->msg = err.what ();
+        device->msg = strdup (err.what ());
     }
 }
 
@@ -137,7 +143,7 @@ unsigned int rtmidi_get_port_count (RtMidiPtr device)
 
     } catch (const RtMidiError & err) {
         device->ok  = false;
-        device->msg = err.what ();
+        device->msg = strdup (err.what ());
         return -1;
     }
 }
@@ -153,7 +159,7 @@ int rtmidi_get_port_name (RtMidiPtr device, unsigned int portNumber, char * bufO
         name = ((RtMidi*) device->ptr)->getPortName (portNumber);
     } catch (const RtMidiError & err) {
         device->ok  = false;
-        device->msg = err.what ();
+        device->msg = strdup (err.what ());
         return -1;
     }
 
@@ -182,7 +188,7 @@ RtMidiInPtr rtmidi_in_create_default ()
         wrp->ptr = 0;
         wrp->data = 0;
         wrp->ok  = false;
-        wrp->msg = err.what ();
+        wrp->msg = strdup (err.what ());
     }
 
     return wrp;
@@ -205,7 +211,7 @@ RtMidiInPtr rtmidi_in_create (enum RtMidiApi api, const char *clientName, unsign
         wrp->ptr = 0;
         wrp->data = 0;
         wrp->ok  = false;
-        wrp->msg = err.what ();
+        wrp->msg = strdup (err.what ());
     }
 
     return wrp;
@@ -226,7 +232,7 @@ enum RtMidiApi rtmidi_in_get_current_api (RtMidiPtr device)
 
     } catch (const RtMidiError & err) {
         device->ok  = false;
-        device->msg = err.what ();
+        device->msg = strdup (err.what ());
 
         return RTMIDI_API_UNSPECIFIED;
     }
@@ -246,7 +252,7 @@ void rtmidi_in_set_callback (RtMidiInPtr device, RtMidiCCallback callback, void 
         ((RtMidiIn*) device->ptr)->setCallback (callback_proxy, device->data);
     } catch (const RtMidiError & err) {
         device->ok  = false;
-        device->msg = err.what ();
+        device->msg = strdup (err.what ());
         delete (CallbackProxyUserData*) device->data;
         device->data = 0;
     }
@@ -260,7 +266,7 @@ void rtmidi_in_cancel_callback (RtMidiInPtr device)
         device->data = 0;
     } catch (const RtMidiError & err) {
         device->ok  = false;
-        device->msg = err.what ();
+        device->msg = strdup (err.what ());
     }
 }
 
@@ -287,7 +293,7 @@ double rtmidi_in_get_message (RtMidiInPtr device,
     }
     catch (const RtMidiError & err) {
         device->ok  = false;
-        device->msg = err.what ();
+        device->msg = strdup (err.what ());
         return -1;
     }
     catch (...) {
@@ -314,7 +320,7 @@ RtMidiOutPtr rtmidi_out_create_default ()
         wrp->ptr = 0;
         wrp->data = 0;
         wrp->ok  = false;
-        wrp->msg = err.what ();
+        wrp->msg = strdup (err.what ());
     }
 
     return wrp;
@@ -337,7 +343,7 @@ RtMidiOutPtr rtmidi_out_create (enum RtMidiApi api, const char *clientName)
         wrp->ptr = 0;
         wrp->data = 0;
         wrp->ok  = false;
-        wrp->msg = err.what ();
+        wrp->msg = strdup (err.what ());
     }
 
 
@@ -357,7 +363,7 @@ enum RtMidiApi rtmidi_out_get_current_api (RtMidiPtr device)
 
     } catch (const RtMidiError & err) {
         device->ok  = false;
-        device->msg = err.what ();
+        device->msg = strdup (err.what ());
 
         return RTMIDI_API_UNSPECIFIED;
     }
@@ -371,7 +377,7 @@ int rtmidi_out_send_message (RtMidiOutPtr device, const unsigned char *message, 
     }
     catch (const RtMidiError & err) {
         device->ok  = false;
-        device->msg = err.what ();
+        device->msg = strdup (err.what ());
         return -1;
     }
     catch (...) {

--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -31,6 +31,10 @@
 #define RTMIDIAPI //__declspec(dllimport)
 #endif
 
+#if defined _WIN32
+#define strdup _strdup
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -134,6 +138,9 @@ RTMIDIAPI enum RtMidiApi rtmidi_compiled_api_by_name(const char *name);
 
 //! \internal Report an error.
 RTMIDIAPI void rtmidi_error (enum RtMidiErrorType type, const char* errorString);
+
+//! \brief Resets the ok flag and the error message.
+RTMIDIAPI void rtmidi_clear_error (RtMidiPtr device);
 
 /*! \brief Open a MIDI port.
  *


### PR DESCRIPTION
Hi,

I don't know if you might be interested or not by this pull request, but I'm making a wrapper around the library with Deno, something similar to what was made here for Node JS : https://github.com/justinlatimer/node-midi

And while trying to handle errors, I noticed two things : 
- The msg member of the device struct was set from a reference to an exception, and was then incorrect when the exception got out of scope (dangling pointer)
- Once an error was met, the ok flag was set to false forever

It's kinda specific to that type of usage though, because I call the library with FFI bindings and then read the methods' results, so it's probably not required for a "classic" usage linking to a native C/C++ application.

Anyway, I'm open to your opinion on that :)

Cheers