### PR TITLE
ALSA: Avoid listing ports with SND_SEQ_PORT_CAP_NO_EXPORT (capabilities)

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -2087,7 +2087,9 @@ unsigned int portInfo( snd_seq_t *seq, snd_seq_port_info_t *pinfo, unsigned int 
            ( ( atyp & SND_SEQ_PORT_TYPE_APPLICATION ) == 0 ) ) continue;
 
       unsigned int caps = snd_seq_port_info_get_capability( pinfo );
-      if ( ( caps & type ) != type ) continue;
+      if ( ( ( caps & type ) != type ) ||
+           ( ( caps & SND_SEQ_PORT_CAP_NO_EXPORT ) != 0 ) ) continue;
+
       if ( count == portNumber ) return 1;
       ++count;
     }


### PR DESCRIPTION
 Avoid listing ports that are usually from 3rd.party managers or clients that have no subscriptable ports at all.