### PR TITLE
CoreMIDI: Fix time delta for messages within same MIDI packet

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1116,6 +1116,8 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
                 std::cerr << "\nMidiInCore: message queue limit reached!!\n\n";
             }
             message.bytes.clear();
+            // All subsequent messages within same MIDI packet will have time delta 0
+            message.timeStamp = 0.0;
           }
           iByte += size;
         }


### PR DESCRIPTION
Single MIDI packet can contain multiple MIDI messages.
The first message within the packet has time delta relative to previous MIDI packet, but remaining MIDI messages have time delta 0 relative to the first message.