### PR TITLE
Fix a CFStringRef leak in RTMidi Port Name

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1376,6 +1376,7 @@ CFStringRef CreateEndpointName( MIDIEndpointRef endpoint, bool isExternal )
           CFStringInsert( result, 0, CFSTR(" ") );
 
         CFStringInsert( result, 0, str );
+        CFRelease(str);
       }
     }
   }


### PR DESCRIPTION
In certain circumstances when building a compound port name (for instance, with an IAC bus), the string math to concatenate the bus and driver does not release one of the source strings, causing a CFStringRef leak on macOS.

This fixes it by doing the appropriate CFRelease after string concatenation.