### PR TITLE
Fix another CFStr reference leak

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1324,6 +1324,7 @@ CFStringRef CreateEndpointName( MIDIEndpointRef endpoint, bool isExternal )
   MIDIObjectGetStringProperty( endpoint, kMIDIPropertyName, &str );
   if ( str != NULL ) {
     CFStringAppend( result, str );
+    CFRelease(str);
   }
 
   // some MIDI devices have a leading space in endpoint name. trim


### PR DESCRIPTION
Fix another casw where the concatenation of result and str in name creation doesn't release the source which is concated onto result.

Sorry for two PRs here; the condition to tickle this is a bit different than the condition to tickle the other.