### PR TITLE
Allow large SysEx Messages to be broken up into smaller packets when transmitted

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -3142,7 +3142,7 @@ void MidiOutWinMM :: sendMessage( const unsigned char *message, size_t size )
 
   MMRESULT result;
   WinMidiData *data = static_cast<WinMidiData *> (apiData_);
-  if ( message[0] == 0xF0 ) { // Sysex message
+  if ( nBytes > 3 ) { // Sysex message
 
     // Allocate buffer for sysex data.
     char *buffer = (char *) malloc( nBytes );
@@ -3182,13 +3182,6 @@ void MidiOutWinMM :: sendMessage( const unsigned char *message, size_t size )
     free( buffer );
   }
   else { // Channel or system message.
-
-    // Make sure the message size isn't too big.
-    if ( nBytes > 3 ) {
-      errorString_ = "MidiOutWinMM::sendMessage: message size is greater than 3 bytes (and not sysex)!";
-      error( RtMidiError::WARNING, errorString_ );
-      return;
-    }
 
     // Pack MIDI bytes into double word.
     DWORD packet;

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1675,12 +1675,6 @@ void MidiOutCore :: sendMessage( const unsigned char *message, size_t size )
     return;
   }
 
-  if ( message[0] != 0xF0 && nBytes > 3 ) {
-    errorString_ = "MidiOutCore::sendMessage: message format problem ... not sysex but > 3 bytes?";
-    error( RtMidiError::WARNING, errorString_ );
-    return;
-  }
-
   MIDITimeStamp timeStamp = AudioGetCurrentHostTime();
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
   OSStatus result;


### PR DESCRIPTION
We have found that older/slower systems can choke when sending large (> 100k) SysEx firmware payloads to our devices, which can cause problems with devices out in the field. To make our end user device firmware update process safer, we need to be able to slow down the transmission of these payloads and break them into smaller chunks.

Currently both the MacOS and Windows sendMessage methods check to see if the first byte is a SysEx start byte (0xF0) before allowing a > 3 byte message to be sent. If the first byte is not 0xF0, an error message is returned and the message is rejected. This not only inhibits our ability to break up the SysEx payload, it seems antithetical to RtMIDI's role as an agnostic transport that does not parse or format messages. It should be up to the application to determine if messages are formatted correctly, RtMIDI should just send and receive data.

This PR removes the blocking 0xF0 check on MacOS entirely. RtMIDI has not used the CoreMIDI sysex specific message method for years, and the standard send is still perfectly fine for this purpose. 

On Windows, we've replaced the 0xF0 check with a size check - messages >3 bytes use the sysex method, otherwise the standard channel/realtime method is used. 

The Alsa/Jack send methods do not have a 0xF0 check, so we did not modify them. 

We've extensively tested this PR with whole and broken up SysEx payloads, on Windows and MacOS, with newer and older machines. This solved the issues we were having sending firmware updates.