### PR TITLE
fix: link error for testcapi

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,7 @@ AS_IF([test "x$AR" = "xno"], [
 ])
 
 LT_INIT([win32-dll])
+AM_CONDITIONAL([enable_shared], [test "$enable_shared" = "yes"])
 AC_CONFIG_MACRO_DIR([m4])
 
 # Checks for header files.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -31,6 +31,9 @@ apinames_LDADD = $(top_builddir)/librtmidi.la
 
 testcapi_SOURCES = testcapi.c
 testcapi_LDADD = $(top_builddir)/librtmidi.la
+if !enable_shared
+testcapi_LINK = $(CXXLINK)
+endif
 
 EXTRA_DIST = cmidiin.dsp midiout.dsp midiprobe.dsp qmidiin.dsp	\
 	sysextest.dsp RtMidi.dsw


### PR DESCRIPTION
When building the library as a static library it tries to link testcapi using the C compiler and we get a link error because the C++ support is missing.

We enable link of testcapi using C++ when shared library is disabled.