### PR TITLE
Android: prevent missing PROPERTY_NAME from causing a nullptr dereference.

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -5004,7 +5004,13 @@ static std::string androidPortName(JNIEnv *env, unsigned int portNumber) {
   auto bundleClass = env->FindClass("android/os/Bundle");
   auto getStringMethod = env->GetMethodID(bundleClass, "getString", "(Ljava/lang/String;)Ljava/lang/String;");
   auto jPortName = (jstring) env->CallObjectMethod(bundle, getStringMethod, env->NewStringUTF("name"));
-
+  if (jPortName == nullptr) {
+    jPortName = (jstring) env->CallObjectMethod(bundle, getStringMethod, env->NewStringUTF("product"));
+    if (jPortName == nullptr) {
+      return "";
+    }
+  }
+  
   auto portNameChars = env->GetStringUTFChars(jPortName, NULL);
   auto name = std::string(portNameChars);
   env->ReleaseStringUTFChars(jPortName, portNameChars);


### PR DESCRIPTION
Not all MidiDeviceInfo structs have the PROPERTY_NAME property. To work around this, this will fall back to PROPERTY_PRODUCT, and just return an empty string if that's also missing.