### PR TITLE
warning: variable length arrays in C++ are a Clang extension

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1683,8 +1683,9 @@ void MidiOutCore :: sendMessage( const unsigned char *message, size_t size )
   OSStatus result;
 
   ByteCount bufsize = nBytes > 65535 ? 65535 : nBytes;
-  Byte buffer[bufsize+16]; // pad for other struct members
-  ByteCount listSize = sizeof( buffer );
+  ByteCount listSize = (bufsize+16) * sizeof(Byte);
+  Byte *buffer = (Byte *) alloca(listSize);
+  
   MIDIPacketList *packetList = (MIDIPacketList*)buffer;
 
   ByteCount remainingBytes = nBytes;


### PR DESCRIPTION
warning: variable length arrays in C++ are a Clang extension) extension]  1686 |   Byte buffer[bufsize+16]; // pad for other struct members

I compiled this with `g++` (clang, std c++17) on a recent macOS command line. 