### PR TITLE
Update URLs to new subdomain on mcgill.ca

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ By Gary P. Scavone, 2003-2023.
 
 This distribution of RtMidi contains the following:
 
-- `doc`:      RtMidi documentation (also online at http://caml.music.mcgill.ca/~gary/rtmidi/)
+- `doc`:      RtMidi documentation (also online at https://caml.music.mcgill.ca/~gary/rtmidi/)
 - `tests`:    example RtMidi programs
 
 On Unix systems, type `./configure` in the top level directory, then `make` in the `tests/` directory to compile the test programs.  In Windows, open the Visual C++ workspace file located in the `tests/` directory.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ By Gary P. Scavone, 2003-2023.
 
 This distribution of RtMidi contains the following:
 
-- `doc`:      RtMidi documentation (also online at http://www.music.mcgill.ca/~gary/rtmidi/)
+- `doc`:      RtMidi documentation (also online at http://caml.music.mcgill.ca/~gary/rtmidi/)
 - `tests`:    example RtMidi programs
 
 On Unix systems, type `./configure` in the top level directory, then `make` in the `tests/` directory to compile the test programs.  In Windows, open the Visual C++ workspace file located in the `tests/` directory.

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -6,7 +6,7 @@
     MIDI input/output subclasses RtMidiIn and RtMidiOut.
 
     RtMidi GitHub site: https://github.com/thestk/rtmidi
-    RtMidi WWW site: http://caml.music.mcgill.ca/~gary/rtmidi/
+    RtMidi WWW site: https://caml.music.mcgill.ca/~gary/rtmidi/
 
     RtMidi: realtime MIDI i/o C++ classes
     Copyright (c) 2003-2023 Gary P. Scavone

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -6,7 +6,7 @@
     MIDI input/output subclasses RtMidiIn and RtMidiOut.
 
     RtMidi GitHub site: https://github.com/thestk/rtmidi
-    RtMidi WWW site: http://www.music.mcgill.ca/~gary/rtmidi/
+    RtMidi WWW site: http://caml.music.mcgill.ca/~gary/rtmidi/
 
     RtMidi: realtime MIDI i/o C++ classes
     Copyright (c) 2003-2023 Gary P. Scavone

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -6,7 +6,7 @@
     MIDI input/output subclasses RtMidiIn and RtMidiOut.
 
     RtMidi GitHub site: https://github.com/thestk/rtmidi
-    RtMidi WWW site: http://caml.music.mcgill.ca/~gary/rtmidi/
+    RtMidi WWW site: https://caml.music.mcgill.ca/~gary/rtmidi/
 
     RtMidi: realtime MIDI i/o C++ classes
     Copyright (c) 2003-2023 Gary P. Scavone

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -6,7 +6,7 @@
     MIDI input/output subclasses RtMidiIn and RtMidiOut.
 
     RtMidi GitHub site: https://github.com/thestk/rtmidi
-    RtMidi WWW site: http://www.music.mcgill.ca/~gary/rtmidi/
+    RtMidi WWW site: http://caml.music.mcgill.ca/~gary/rtmidi/
 
     RtMidi: realtime MIDI i/o C++ classes
     Copyright (c) 2003-2023 Gary P. Scavone

--- a/doc/doxygen/tutorial.txt
+++ b/doc/doxygen/tutorial.txt
@@ -26,7 +26,7 @@ The version number has been bumped to 6.0.0 because new APIs (Android and Window
 
 \section download Download
 
-Latest Release (3 August 2023): <A href="http://caml.music.mcgill.ca/~gary/rtmidi/release/rtmidi-6.0.0.tar.gz">Version 6.0.0</A>
+Latest Release (3 August 2023): <A href="https://caml.music.mcgill.ca/~gary/rtmidi/release/rtmidi-6.0.0.tar.gz">Version 6.0.0</A>
 
 \section start Getting Started
 

--- a/doc/doxygen/tutorial.txt
+++ b/doc/doxygen/tutorial.txt
@@ -26,7 +26,7 @@ The version number has been bumped to 6.0.0 because new APIs (Android and Window
 
 \section download Download
 
-Latest Release (3 August 2023): <A href="http://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-6.0.0.tar.gz">Version 6.0.0</A>
+Latest Release (3 August 2023): <A href="http://caml.music.mcgill.ca/~gary/rtmidi/release/rtmidi-6.0.0.tar.gz">Version 6.0.0</A>
 
 \section start Getting Started
 


### PR DESCRIPTION
ref:  #354

- Update the remainder of URLs to caml.music.mcgill.ca
- s/http/https/ for each link changed.

Thanks!
