### PR TITLE
Add support for C++20 modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,10 @@ option(RTMIDI_API_CORE "Compile with CoreMIDI support." ${APPLE})
 option(RTMIDI_API_ALSA "Compile with ALSA support." ${ALSA})
 option(RTMIDI_API_AMIDI "Compile with Android support." ${ANDROID})
 
+# Module options
+option(RTMIDI_BUILD_MODULES "Build C++ modules for RtMidi" OFF)
+option(RTMIDI_USE_NAMESPACE "Use namespace rtmidi for module" ON)
+
 # Add -Wall if possible
 if (CMAKE_COMPILER_IS_GNUCXX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
@@ -214,6 +218,15 @@ target_compile_definitions(rtmidi PRIVATE ${API_DEFS})
 target_compile_definitions(rtmidi PRIVATE RTMIDI_EXPORT)
 target_link_libraries(rtmidi PUBLIC ${PUBLICLINKLIBS} 
                              PRIVATE ${LINKLIBS})
+
+if(RTMIDI_BUILD_MODULES)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+    message(STATUS "Building rtmidi C++ module")
+    add_subdirectory(modules)
+  else()
+    message(WARNING "Skipping rtmidi C++ module (requires CMake 3.28+, found ${CMAKE_VERSION})")
+  endif()
+endif()
 
 # Add tests if requested.
 option(RTMIDI_BUILD_TESTING "Build test programs" ON)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ RtMidi is a set of C++ classes (`RtMidiIn`, `RtMidiOut`, and API specific classe
 
 MIDI input and output functionality are separated into two classes, `RtMidiIn` and `RtMidiOut`.  Each class instance supports only a single MIDI connection.  RtMidi does not provide timing functionality (i.e., output messages are sent immediately).  Input messages are timestamped with delta times in seconds (via a `double` floating point type).  MIDI data is passed to the user as raw bytes using an `std::vector<unsigned char>`.
 
+RtMidi is also offered as a module, which is enabled with `RTMIDI_BUILD_MODULES`, and is accessed with `import rtmidi;`. Namespaces are inlined, so classes can be accessed through namespace `rtmidi` or through the global namespace (for example, `rtmidi::MidiApi` and `::MidiApi` are both valid).
+
 ## Windows
 
 In some cases, for example to use RtMidi with GS Synth, it may be necessary for your program to call `CoInitializeEx` and `CoUninitialize` on entry to and exit from the thread that uses RtMidi.

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -39,6 +39,9 @@
 
 #include "RtMidi.h"
 #include <sstream>
+
+inline namespace rtmidi {
+
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
 #endif
@@ -5269,3 +5272,5 @@ void MidiOutAndroid :: sendMessage( const unsigned char *message, size_t size ) 
 }
 
 #endif  // __AMIDI__
+
+}

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -82,6 +82,7 @@
 #include <string>
 #include <vector>
 
+inline namespace rtmidi {
 
 /************************************************************************/
 /*! \class RtMidiError
@@ -673,5 +674,7 @@ inline std::string RtMidiOut :: getPortName( unsigned int portNumber ) { return 
 inline void RtMidiOut :: sendMessage( const std::vector<unsigned char> *message ) { static_cast<MidiOutApi *>(rtapi_)->sendMessage( &message->at(0), message->size() ); }
 inline void RtMidiOut :: sendMessage( const unsigned char *message, size_t size ) { static_cast<MidiOutApi *>(rtapi_)->sendMessage( message, size ); }
 inline void RtMidiOut :: setErrorCallback( RtMidiErrorCallback errorCallback, void *userData ) { rtapi_->setErrorCallback(errorCallback, userData); }
+
+}
 
 #endif

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.28)
+
+add_library(rtmidi_modules)
+
+set(RTMIDI_MODULES
+    RtMidi.cppm
+)
+
+if(NOT COMMAND configure_cpp_module_target)
+    function(configure_cpp_module_target target)
+        target_sources(${target} PUBLIC FILE_SET CXX_MODULES FILES ${RTMIDI_MODULES})
+    endfunction()
+endif()
+
+configure_cpp_module_target(rtmidi_modules)
+
+target_link_libraries(rtmidi_modules
+    PUBLIC
+    rtmidi
+)
+
+target_include_directories(rtmidi_modules
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}
+)
+
+target_compile_features(rtmidi_modules PUBLIC cxx_std_20)

--- a/modules/RtMidi.cppm
+++ b/modules/RtMidi.cppm
@@ -1,0 +1,16 @@
+module;
+
+#include "RtMidi.h"
+
+export module rtmidi;
+
+export inline namespace rtmidi {
+    using rtmidi::RtMidiError;
+    using rtmidi::RtMidiErrorCallback;
+    using rtmidi::RtMidi;
+    using rtmidi::RtMidiIn;
+    using rtmidi::RtMidiOut;
+    using rtmidi::MidiApi;
+    using rtmidi::MidiInApi;
+    using rtmidi::MidiOutApi;
+}


### PR DESCRIPTION
This pull request adds support for C++20 modules, as well as puts all symbols in the inlined namespace `rtmidi`. This change does not break any existing code, but allows symbols to be optionally accessed through the namespace `rtmidi` in addition to the global namespace. The module itself is imported using `import rtmidi;` and is enabled with the build macro `RTMIDI_BUILD_MODULES`.