### PR TITLE
Add `rtmidi_set_error_callback` to C wrapper

### DIFF
--- a/rtmidi_c.h
+++ b/rtmidi_c.h
@@ -39,10 +39,11 @@ extern "C" {
 struct RtMidiWrapper {
     //! The wrapped RtMidi object.
     void* ptr;
-    void* data;
+    void* callback_proxy;
+    void* error_callback_proxy;
 
     //! True when the last function call was OK.
-    bool  ok;
+    bool ok;
 
     //! If an error occurred (ok != true), set to an error message.
     char* msg;
@@ -97,6 +98,17 @@ enum RtMidiErrorType {
 typedef void(* RtMidiCCallback) (double timeStamp, const unsigned char* message,
                                  size_t messageSize, void *userData);
 
+/*! \brief The type of a RtMidi error callback function.
+ *
+ * \param type        Type of error
+ * \param message     Error description
+ * \param userData    Additional user data for the callback.
+ *
+ * See \ref MidiApi::setErrorCallback.
+ */
+typedef void(* RtMidiErrorCCallback) (enum RtMidiErrorType type,
+                                      const char *errorText,
+                                      void *userData);
 
 /* RtMidi API */
 
@@ -131,9 +143,6 @@ RTMIDIAPI const char *rtmidi_api_display_name(enum RtMidiApi api);
 //! \brief Return the compiled MIDI API having the given name.
 //! See \ref RtMidi::getCompiledApiByName().
 RTMIDIAPI enum RtMidiApi rtmidi_compiled_api_by_name(const char *name);
-
-//! \internal Report an error.
-RTMIDIAPI void rtmidi_error (enum RtMidiErrorType type, const char* errorString);
 
 /*! \brief Open a MIDI port.
  *
@@ -250,6 +259,9 @@ RTMIDIAPI enum RtMidiApi rtmidi_out_get_current_api (RtMidiPtr device);
 //! See \ref RtMidiOut::sendMessage().
 RTMIDIAPI int rtmidi_out_send_message (RtMidiOutPtr device, const unsigned char *message, int length);
 
+//! \brief Set error callback function on a RtMidiPtr.
+//! See \ref MidiApi::setErrorCallback().
+RTMIDIAPI void rtmidi_set_error_callback (RtMidiPtr device, RtMidiErrorCCallback callback, void *userData);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Without setting a callback, all errors are printed to stderr, which may not be desirable.

Rename `data` field in wrapper struct to something more descriptive.

Delete `rtmidi_error` function as the prototype mismatched the implementation.

Templatize existing callback proxy class so we can reuse it for error callbacks.

This is an ABI break as it adds a field to the wrapper struct.

Test script:

```c
#include <stdio.h>
#include <rtmidi_c.h>

static void error_cb(enum RtMidiErrorType type, const char *msg, void *udata) {
    printf("error_cb: type=%d msg=%s udata=%p\n", type, msg, udata);
}

int main(int argc, char **argv) {
    RtMidiOutPtr out = rtmidi_out_create(0, argv[0]);
    rtmidi_set_error_callback(out, error_cb, (void *)0xffff);
    rtmidi_open_port(out, 999, "invalid_port");
    rtmidi_out_free(out);
    return 0;
}
```

```console
$ ./test
error_cb: type=6 msg=MidiOutAlsa::openPort: the 'portNumber' argument (999) is invalid. udata=0xffff
```
