### PR TITLE
Fix build error caused by use of deprecated POSIX name of `strdup`

### DIFF
--- a/rtmidi_c.cpp
+++ b/rtmidi_c.cpp
@@ -417,5 +417,5 @@ static void rtmidi_set_error_msg (RtMidiPtr device, const char *err)
     if (device->msg) {
         free (device->msg);
     }
-    device->msg = strdup(err);
+    device->msg = _strdup(err);
 }

--- a/rtmidi_c.cpp
+++ b/rtmidi_c.cpp
@@ -3,6 +3,11 @@
 #include "rtmidi_c.h"
 #include "RtMidi.h"
 
+// Fixes build error C4996 on Windows 11 with VS2022
+#ifdef _MSC_VER
+#define strdup _strdup
+#endif
+
 /* Compile-time assertions that will break if the enums are changed in
  * the future without synchronizing them properly.  If you get (g++)
  * "error: ‘StaticEnumAssert<b>::StaticEnumAssert() [with bool b = false]’
@@ -417,5 +422,5 @@ static void rtmidi_set_error_msg (RtMidiPtr device, const char *err)
     if (device->msg) {
         free (device->msg);
     }
-    device->msg = _strdup(err);
+    device->msg = strdup(err);
 }


### PR DESCRIPTION
Changes `strdup` to `_strdup`

Fixes the following build error on Windows 11 with VS2022:

```
rtmidi_c.cpp(420,19): error C4996: 'strdup': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _strdup. See online help for details.
```