### PR TITLE
Replace inline namespace with implicitly imported namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ RtMidi is a set of C++ classes (`RtMidiIn`, `RtMidiOut`, and API specific classe
 
 MIDI input and output functionality are separated into two classes, `RtMidiIn` and `RtMidiOut`.  Each class instance supports only a single MIDI connection.  RtMidi does not provide timing functionality (i.e., output messages are sent immediately).  Input messages are timestamped with delta times in seconds (via a `double` floating point type).  MIDI data is passed to the user as raw bytes using an `std::vector<unsigned char>`.
 
-RtMidi is also offered as a module, which is enabled with `RTMIDI_BUILD_MODULES`, and is accessed with `import rt.midi;`. Namespaces are inlined, so classes can be accessed through namespace `rt::midi` or through the global namespace (for example, `rt::midi::MidiApi` and `::MidiApi` are both valid).
+RtMidi is also offered as a module, which is enabled with `RTMIDI_BUILD_MODULES`, and is accessed with `import rt.midi;`. Namespaces are implicitly imported (unless disabled with `RTMIDI_USE_NAMESPACE`), so classes can be accessed through namespace `rt::midi` or through the global namespace (for example, `rt::midi::MidiApi` and `::MidiApi` are both valid).
 
 ## Windows
 

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -40,8 +40,7 @@
 #include "RtMidi.h"
 #include <sstream>
 
-inline namespace rt {
-inline namespace midi {
+using namespace rt::midi;
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
@@ -5274,6 +5273,3 @@ void MidiOutAndroid :: sendMessage( const unsigned char *message, size_t size ) 
 }
 
 #endif  // __AMIDI__
-
-}
-}

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -82,8 +82,7 @@
 #include <string>
 #include <vector>
 
-inline namespace rt {
-inline namespace midi {
+namespace rt::midi {
 
 /************************************************************************/
 /*! \class RtMidiError
@@ -677,6 +676,9 @@ inline void RtMidiOut :: sendMessage( const unsigned char *message, size_t size 
 inline void RtMidiOut :: setErrorCallback( RtMidiErrorCallback errorCallback, void *userData ) { rtapi_->setErrorCallback(errorCallback, userData); }
 
 }
-}
 
+#endif
+
+#ifndef RTMIDI_USE_NAMESPACE
+using namespace rt::midi;
 #endif

--- a/modules/RtMidi.cppm
+++ b/modules/RtMidi.cppm
@@ -4,13 +4,7 @@ module;
 
 export module rt.midi;
 
-export
-#ifndef RTMIDI_USE_NAMESPACE
-inline namespace rt {
-inline namespace midi {
-#else
-namespace rt::midi {
-#endif
+export namespace rt::midi {
     using rt::midi::RtMidiError;
     using rt::midi::RtMidiErrorCallback;
     using rt::midi::RtMidi;
@@ -20,6 +14,7 @@ namespace rt::midi {
     using rt::midi::MidiInApi;
     using rt::midi::MidiOutApi;
 }
+
 #ifndef RTMIDI_USE_NAMESPACE
-}
+using namespace rt::midi;
 #endif


### PR DESCRIPTION
This pull request replaces `inline namespace` with a strict `namespace`, which avoids additional preprocessor logic in the module file, and adds `using namespace rt::midi;` unless `RTMIDI_USE_NAMESPACE` is enabled (to avoid breaking code that accesses `rt::midi` classes through the global namespace).