### PR TITLE
Use old nested namespace declaration for C++11 compatibility

### DIFF
--- a/RtMidi.h
+++ b/RtMidi.h
@@ -82,7 +82,8 @@
 #include <string>
 #include <vector>
 
-namespace rt::midi {
+namespace rt {
+namespace midi {
 
 /************************************************************************/
 /*! \class RtMidiError
@@ -675,7 +676,8 @@ inline void RtMidiOut :: sendMessage( const std::vector<unsigned char> *message 
 inline void RtMidiOut :: sendMessage( const unsigned char *message, size_t size ) { static_cast<MidiOutApi *>(rtapi_)->sendMessage( message, size ); }
 inline void RtMidiOut :: setErrorCallback( RtMidiErrorCallback errorCallback, void *userData ) { rtapi_->setErrorCallback(errorCallback, userData); }
 
-}
+} // namespace midi
+} // namespace rt
 
 #endif
 


### PR DESCRIPTION
Fixes a related problem that happened on RtAudio, from  #364. Replace `namespace rt::midi {}` with `namespace rt { namespace midi {} }` to ensure that compatibility with C++<17 is not broken.