### PR TITLE
Small fixes: uninstall target guard, signed/unsigned compare, dead link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,8 +294,13 @@ configure_file(
     "${CMAKE_BINARY_DIR}/RtMidiConfigUninstall.cmake" @ONLY)
 
 # Create uninstall target.
-add_custom_target(${RTMIDI_TARGETNAME_UNINSTALL}
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}/RtMidiConfigUninstall.cmake)
+# Guard against the target already existing: when RtMidi is added as a
+# subproject alongside another library that defines its own 'uninstall'
+# target, redefining it is an error (fatal as of CMake 4.1).
+if(NOT TARGET ${RTMIDI_TARGETNAME_UNINSTALL})
+  add_custom_target(${RTMIDI_TARGETNAME_UNINSTALL}
+      COMMAND ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}/RtMidiConfigUninstall.cmake)
+endif()
 
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/rtmidi.pc

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1399,7 +1399,7 @@ static CFStringRef CreateConnectedEndpointName( MIDIEndpointRef endpoint )
   CFMutableStringRef result = CFStringCreateMutable( NULL, 0 );
   CFStringRef str;
   OSStatus err;
-  int i;
+  size_t i;
 
   // Does the endpoint have connections?
   CFDataRef connections = NULL;
@@ -2687,7 +2687,7 @@ struct WinMidiData {
   DWORD lastTime;
   MidiInApi::MidiMessage message;
   std::vector<LPMIDIHDR> sysexBuffer;
-  CRITICAL_SECTION _mutex; // [Patrice] see https://groups.google.com/forum/#!topic/mididev/6OUjHutMpEo
+  CRITICAL_SECTION _mutex; // [Patrice] protects the sysex buffer requeue in midiInputCallback
 };
 
 //*********************************************************************//


### PR DESCRIPTION
Three small unrelated fixes, each closing an open issue.

**#369** — `add_custom_target(uninstall)` is created unconditionally, which fails configuration when RtMidi is added as a subproject alongside another library that defines its own `uninstall` target. Previously tolerated; fatal as of CMake 4.1. Guarded with `if(NOT TARGET ...)`.

**#291** — `CreateConnectedEndpointName` declares `int i` and compares it against `size_t nConnected`. The `nConnected` half was already changed to `size_t` upstream; this changes `i` to match.

**#371** — the mididev Google Groups thread referenced in `WinMidiData` is no longer publicly reachable (the group returns an access error). Replaced the link with what it explained, keeping the attribution.

Verified on Linux (ALSA + JACK), CMake configure and build clean. The `#291` change is in CoreMIDI code, which does not compile on Linux — worth a look from someone on macOS.