### PR TITLE
ALSA: accept partial SysEx spans in MidiOutAlsa::sendMessage

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -2598,15 +2598,20 @@ void MidiOutAlsa :: sendMessage( const unsigned char *message, size_t size )
   if ( nBytes > 0 ) {
     const unsigned char first = message[0];
     if ( data->sysexInProgress || first == 0xF0 ) {
-      // Track completion so the next call knows whether it is a continuation.
+      // Work out the framing state this buffer leaves behind, but commit it
+      // only once the event has been accepted (below). If the send fails, the
+      // state stays as it was, so a caller that retries the same span gets it
+      // routed the same way; otherwise a retried continuation would fall
+      // through to the encoder and be rejected as an incomplete message.
       // Real-time bytes (0xF8-0xFF) may appear mid-SysEx without ending it;
       // F7 ends it, and so does any other non-real-time status byte.
+      bool nextSysexInProgress = data->sysexInProgress;
       for ( unsigned int i = 0; i < nBytes; ++i ) {
         const unsigned char b = message[i];
         if ( b >= 0xF8 ) continue;
-        if ( b == 0xF0 ) { data->sysexInProgress = true; continue; }
-        if ( b == 0xF7 ) { data->sysexInProgress = false; continue; }
-        if ( b >= 0x80 ) data->sysexInProgress = false;
+        if ( b == 0xF0 ) { nextSysexInProgress = true; continue; }
+        if ( b == 0xF7 ) { nextSysexInProgress = false; continue; }
+        if ( b >= 0x80 ) nextSysexInProgress = false;
       }
 
       snd_seq_event_t ev;
@@ -2617,15 +2622,14 @@ void MidiOutAlsa :: sendMessage( const unsigned char *message, size_t size )
       snd_seq_ev_set_sysex( &ev, nBytes, const_cast<unsigned char *>( message ) );
       result = snd_seq_event_output( data->seq, &ev );
       if ( result < 0 ) {
-        // The failure also ends the SysEx framing state: a caller that hits an
-        // error part-way through abandons that message, and a stale
-        // in-progress flag would route its next, unrelated, message down this
-        // path instead of the encoder.
-        data->sysexInProgress = false;
         errorString_ = "MidiOutAlsa::sendMessage: error sending MIDI message to port.";
         error( RtMidiError::WARNING, errorString_ );
         return;
       }
+
+      // The event has been accepted, so the framing state moves on.
+      data->sysexInProgress = nextSysexInProgress;
+
       snd_seq_drain_output( data->seq );
       return;
     }

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1771,6 +1771,10 @@ struct AlsaMidiData {
   snd_seq_real_time_t lastTime;
   int queue_id; // an input queue is needed to get timestamped events
   int trigger_fds[2];
+  // Output-side SysEx state: true once 0xF0 has been seen and no 0xF7 (or
+  // other terminating status byte) has arrived yet, so a later call carrying
+  // a bare continuation span can be recognized as part of the same message.
+  bool sysexInProgress = false;
 };
 
 #define PORT_TYPE( pinfo, bits ) ((snd_seq_port_info_get_capability(pinfo) & (bits)) == (bits))
@@ -2576,6 +2580,51 @@ void MidiOutAlsa :: sendMessage( const unsigned char *message, size_t size )
   long result;
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   unsigned int nBytes = static_cast<unsigned int> (size);
+
+  // A large SysEx may be handed to sendMessage() across several calls - an
+  // opening F0.. with no F7, bare continuation bytes, then a span ending in
+  // F7 - so that the caller can pace the transfer and produce real
+  // inter-span gaps on the wire.
+  //
+  // snd_midi_event_encode() only emits an event for a self-contained message
+  // and returns SND_SEQ_EVENT_NONE for any such span, which the loop below
+  // reports as "incomplete message!" and drops. ALSA's native transport for a
+  // large SysEx is exactly a sequence of SysEx events carrying arbitrary byte
+  // spans, which the receiver concatenates until F7 - the mirror of the
+  // reassembly MidiInAlsa already performs - so emit those directly and
+  // bypass the encoder. The other backends already accept partial SysEx this
+  // way; this brings ALSA into line with them.
+  if ( nBytes > 0 ) {
+    const unsigned char first = message[0];
+    if ( data->sysexInProgress || first == 0xF0 ) {
+      // Track completion so the next call knows whether it is a continuation.
+      // Real-time bytes (0xF8-0xFF) may appear mid-SysEx without ending it;
+      // F7 ends it, and so does any other non-real-time status byte.
+      for ( unsigned int i = 0; i < nBytes; ++i ) {
+        const unsigned char b = message[i];
+        if ( b >= 0xF8 ) continue;
+        if ( b == 0xF0 ) { data->sysexInProgress = true; continue; }
+        if ( b == 0xF7 ) { data->sysexInProgress = false; continue; }
+        if ( b >= 0x80 ) data->sysexInProgress = false;
+      }
+
+      snd_seq_event_t ev;
+      snd_seq_ev_clear( &ev );
+      snd_seq_ev_set_source( &ev, data->vport );
+      snd_seq_ev_set_subs( &ev );
+      snd_seq_ev_set_direct( &ev );
+      snd_seq_ev_set_sysex( &ev, nBytes, const_cast<unsigned char *>( message ) );
+      result = snd_seq_event_output( data->seq, &ev );
+      if ( result < 0 ) {
+        errorString_ = "MidiOutAlsa::sendMessage: error sending MIDI message to port.";
+        error( RtMidiError::WARNING, errorString_ );
+        return;
+      }
+      snd_seq_drain_output( data->seq );
+      return;
+    }
+  }
+
   if ( nBytes > data->bufferSize ) {
     data->bufferSize = nBytes;
     result = snd_midi_event_resize_buffer( data->coder, nBytes );

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -2538,6 +2538,7 @@ void MidiOutAlsa :: closePort( void )
     snd_seq_unsubscribe_port( data->seq, data->subscription );
     snd_seq_port_subscribe_free( data->subscription );
     data->subscription = 0;
+    data->sysexInProgress = false;
     connected_ = false;
   }
 }
@@ -2616,6 +2617,11 @@ void MidiOutAlsa :: sendMessage( const unsigned char *message, size_t size )
       snd_seq_ev_set_sysex( &ev, nBytes, const_cast<unsigned char *>( message ) );
       result = snd_seq_event_output( data->seq, &ev );
       if ( result < 0 ) {
+        // The failure also ends the SysEx framing state: a caller that hits an
+        // error part-way through abandons that message, and a stale
+        // in-progress flag would route its next, unrelated, message down this
+        // path instead of the encoder.
+        data->sysexInProgress = false;
         errorString_ = "MidiOutAlsa::sendMessage: error sending MIDI message to port.";
         error( RtMidiError::WARNING, errorString_ );
         return;


### PR DESCRIPTION
ALSA is the only backend that refuses a SysEx fragment.

`MidiOutAlsa::sendMessage()` re-encodes its bytes through `snd_midi_event_encode()`, which only emits an event for a self-contained message. Hand it a fragment of a larger SysEx and it returns `SND_SEQ_EVENT_NONE`, which the send loop treats as fatal — the bytes are dropped and a WARNING is raised that most callers never see.

CoreMIDI, WinMM, JACK and Web all forward SysEx bytes to the transport as given, so a caller may hand a large SysEx to `sendMessage()` across several calls — an opening `F0..` with no `F7`, bare continuation bytes, then a span ending in `F7` — and have it arrive. Pacing a transfer that way is an established idiom for firmware updates, where the inter-span gaps need to land as real gaps on the wire. On ALSA the same code silently loses everything up to the final span.

## Reproduction

Against alsa-lib 1.2.14 on a real MIDI port, comparing this branch to master at a3233c2. An opening span with no `F7`:

| span | master | this branch |
|---|---|---|
| 4096 B | `incomplete message!` | ok |
| 8192 B | `incomplete message!` | ok |
| 10240 B | `incomplete message!` | ok |

## The change

Track SysEx state on `AlsaMidiData` and, when a call opens or continues a SysEx, emit the bytes with `snd_seq_ev_set_sysex()` instead of running them through the encoder. That is ALSA's native transport for a large SysEx — a sequence of SysEx events carrying arbitrary byte spans, concatenated by the receiver until `F7` — and the mirror of the reassembly `MidiInAlsa` already performs.

Any send failure clears the framing state, and so does `closePort()`: a caller that errors part-way through abandons that message, and a stale in-progress flag would route its next, unrelated, message down this path instead of the encoder.

Anything that is not part of a SysEx takes the original encoder path, unmodified. The diff is 55 insertions and 0 deletions; existing behaviour for channel, system-common and realtime messages is untouched.

No public API change — `RtMidi.h` is not touched.

## What this does not fix

A **single** message larger than roughly 16 KB is refused by `snd_seq_event_output()` with `-EINVAL`, on master and with this change alike. That is a sequencer output-pool limit rather than an encoder one — the exact ceiling tracks the client's output pool size (16355 bytes with the default 500-event pool on the test machine), so it is closer to the input-side concern originally reported in #214.

Streaming a large SysEx as sub-ceiling spans, which this change enables, is a way around it. Raising the ceiling itself — `snd_seq_set_client_pool_output()`, or having `sendMessage()` split internally — is separate work, and I have deliberately not done it here. Happy to follow up if you have a preference on direction.

## Scope

Addresses the ALSA **output** path of #214. The >16 KB single-message ceiling, the input-side kernel buffering keinstein originally described, and the JACK half all remain open.

Adjacent, no conflict expected: #374 touches the same file in the input reconnection path, not `MidiOutAlsa::sendMessage`.

Tested on Linux (ALSA + JACK): Autotools (`autogen.sh`, `configure --with-alsa`, `make`, `make check`) and CMake both configure and build clean, and a 566-chunk / 63 KB firmware update to real hardware completes with no ALSA diagnostics.