### PR TITLE
WinMM: fix SysEx short-tail routing, output buffer lifetime, and input closePort teardown

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -2688,7 +2688,19 @@ struct WinMidiData {
   MidiInApi::MidiMessage message;
   std::vector<LPMIDIHDR> sysexBuffer;
   CRITICAL_SECTION _mutex; // [Patrice] see https://groups.google.com/forum/#!topic/mididev/6OUjHutMpEo
+  // Output-side SysEx framing state: true once 0xF0 has been sent and no 0xF7
+  // (or other terminating status byte) has been seen yet. Lets sendMessage()
+  // route a continuation span to midiOutLongMsg() regardless of its length.
+  bool sysexInProgress = false;
+  // Input-side teardown flag, guarded by _mutex: set while the sysex buffers
+  // are being retired so midiInputCallback() stops requeueing them.
+  bool inputClosing = false;
 };
+
+// How long to wait for a driver to release a buffer (or to close a port that
+// still has buffers queued) before giving up. Deliberately generous: this
+// guards against a driver that never lets go, it is not a tuning value.
+static const DWORD kWinMMBufferReleaseTimeoutMs = 5000;
 
 //*********************************************************************//
 //  API: Windows MM
@@ -2760,10 +2772,16 @@ static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
     // buffer when an application closes and in this case, we should
     // avoid requeueing it, else the computer suddenly reboots after
     // one or two minutes.
-    if ( apiData->sysexBuffer[sysex->dwUser]->dwBytesRecorded > 0 ) {
-      //if ( sysex->dwBytesRecorded > 0 ) {
+    //
+    // Use the header WinMM handed back rather than indexing sysexBuffer: it is
+    // the same object, and the vector is cleared once the port has closed. Do
+    // not requeue while the port is closing, since the buffers are about to be
+    // unprepared and freed.
+    if ( sysex->dwBytesRecorded > 0 ) {
+      MMRESULT result = MMSYSERR_NOERROR;
       EnterCriticalSection( &(apiData->_mutex) );
-      MMRESULT result = midiInAddBuffer( apiData->inHandle, apiData->sysexBuffer[sysex->dwUser], sizeof(MIDIHDR) );
+      if ( !apiData->inputClosing )
+        result = midiInAddBuffer( apiData->inHandle, sysex, sizeof(MIDIHDR) );
       LeaveCriticalSection( &(apiData->_mutex) );
       if ( result != MMSYSERR_NOERROR )
         std::cerr << "\nRtMidiIn::midiInputCallback: error sending sysex to Midi device!!\n\n";
@@ -2788,6 +2806,52 @@ static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
 
   // Clear the vector for the next input message.
   apiData->message.bytes.clear();
+}
+
+// Stop input and release everything MidiInWinMM::openPort() acquired: the
+// sysex buffers and the input handle. Used by closePort() and by openPort()'s
+// own failure paths, so it has to cope with a partly built buffer list.
+//
+// Every step runs regardless of earlier failures and nothing here throws or
+// returns early, so the port can never be left half torn down (see #376).
+// Returns the first failure, or MMSYSERR_NOERROR.
+static MMRESULT releaseWinMMInput( WinMidiData *data )
+{
+  // Stop the callback requeueing buffers before retiring them. The flag is
+  // set under the lock, but the lock is not held across midiInReset(), which
+  // drives the very callbacks that take it.
+  EnterCriticalSection( &(data->_mutex) );
+  data->inputClosing = true;
+  LeaveCriticalSection( &(data->_mutex) );
+
+  midiInReset( data->inHandle );
+  midiInStop( data->inHandle );
+
+  MMRESULT firstFailure = MMSYSERR_NOERROR;
+  for ( size_t i=0; i < data->sysexBuffer.size(); ++i ) {
+    if ( data->sysexBuffer[i] == NULL ) continue;
+    MMRESULT result = midiInUnprepareHeader( data->inHandle, data->sysexBuffer[i], sizeof(MIDIHDR) );
+    if ( result != MMSYSERR_NOERROR ) {
+      // The driver may still own this header, so leak it rather than free it.
+      if ( firstFailure == MMSYSERR_NOERROR ) firstFailure = result;
+      data->sysexBuffer[i] = NULL;
+    }
+  }
+
+  MMRESULT result = midiInClose( data->inHandle );
+  if ( result != MMSYSERR_NOERROR && firstFailure == MMSYSERR_NOERROR ) firstFailure = result;
+  data->inHandle = 0;
+
+  // No callbacks arrive once the handle is closed, so the headers can go now.
+  for ( size_t i=0; i < data->sysexBuffer.size(); ++i ) {
+    if ( data->sysexBuffer[i] == NULL ) continue;
+    delete [] data->sysexBuffer[i]->lpData;
+    delete data->sysexBuffer[i];
+  }
+  data->sysexBuffer.clear();
+  data->inputClosing = false;
+
+  return firstFailure;
 }
 
 MidiInWinMM :: MidiInWinMM( const std::string &clientName, unsigned int queueSizeLimit )
@@ -2868,7 +2932,7 @@ void MidiInWinMM :: openPort( unsigned int portNumber, const std::string &/*port
   // Allocate and init the sysex buffers.
   data->sysexBuffer.resize( inputData_.bufferCount );
   for ( unsigned int i=0; i < inputData_.bufferCount; ++i ) {
-    data->sysexBuffer[i] = (MIDIHDR*) new char[ sizeof(MIDIHDR) ];
+    data->sysexBuffer[i] = new MIDIHDR();
     data->sysexBuffer[i]->lpData = new char[ inputData_.bufferSize ];
     data->sysexBuffer[i]->dwBufferLength = inputData_.bufferSize;
     data->sysexBuffer[i]->dwUser = i; // We use the dwUser parameter as buffer indicator
@@ -2876,8 +2940,7 @@ void MidiInWinMM :: openPort( unsigned int portNumber, const std::string &/*port
 
     result = midiInPrepareHeader( data->inHandle, data->sysexBuffer[i], sizeof(MIDIHDR) );
     if ( result != MMSYSERR_NOERROR ) {
-      midiInClose( data->inHandle );
-      data->inHandle = 0;
+      releaseWinMMInput( data );
       errorString_ = "MidiInWinMM::openPort: error starting Windows MM MIDI input port (PrepareHeader).";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
@@ -2886,8 +2949,7 @@ void MidiInWinMM :: openPort( unsigned int portNumber, const std::string &/*port
     // Register the buffer.
     result = midiInAddBuffer( data->inHandle, data->sysexBuffer[i], sizeof(MIDIHDR) );
     if ( result != MMSYSERR_NOERROR ) {
-      midiInClose( data->inHandle );
-      data->inHandle = 0;
+      releaseWinMMInput( data );
       errorString_ = "MidiInWinMM::openPort: error starting Windows MM MIDI input port (AddBuffer).";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
@@ -2896,8 +2958,7 @@ void MidiInWinMM :: openPort( unsigned int portNumber, const std::string &/*port
 
   result = midiInStart( data->inHandle );
   if ( result != MMSYSERR_NOERROR ) {
-    midiInClose( data->inHandle );
-    data->inHandle = 0;
+    releaseWinMMInput( data );
     errorString_ = "MidiInWinMM::openPort: error starting Windows MM MIDI input port.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
@@ -2917,27 +2978,18 @@ void MidiInWinMM :: closePort( void )
 {
   if ( connected_ ) {
     WinMidiData *data = static_cast<WinMidiData *> (apiData_);
-    EnterCriticalSection( &(data->_mutex) );
-    midiInReset( data->inHandle );
-    midiInStop( data->inHandle );
-
-    for ( size_t i=0; i < data->sysexBuffer.size(); ++i ) {
-      int result = midiInUnprepareHeader(data->inHandle, data->sysexBuffer[i], sizeof(MIDIHDR));
-      delete [] data->sysexBuffer[i]->lpData;
-      delete [] data->sysexBuffer[i];
-      if ( result != MMSYSERR_NOERROR ) {
-        midiInClose( data->inHandle );
-        data->inHandle = 0;
-        errorString_ = "MidiInWinMM::openPort: error closing Windows MM MIDI input port (midiInUnprepareHeader).";
-        error( RtMidiError::DRIVER_ERROR, errorString_ );
-        return;
-      }
-    }
-
-    midiInClose( data->inHandle );
-    data->inHandle = 0;
+    MMRESULT result = releaseWinMMInput( data );
     connected_ = false;
-    LeaveCriticalSection( &(data->_mutex) );
+
+    // Reported only once the port is fully closed, and as a warning rather
+    // than an error: nothing is left for the caller to act on, and
+    // closePort() also runs from the destructor, where a thrown RtMidiError
+    // would terminate the process.
+    if ( result != MMSYSERR_NOERROR ) {
+      errorString_ = "MidiInWinMM::closePort: error closing Windows MM MIDI input port (MMRESULT " +
+                     std::to_string( result ) + ").";
+      error( RtMidiError::WARNING, errorString_ );
+    }
   }
 }
 
@@ -3106,9 +3158,29 @@ void MidiOutWinMM :: closePort( void )
     // Controllers" (to all 16 channels) CC messages which is undesirable (see issue #222)
     // midiOutReset( data->outHandle );
 
-    midiOutClose( data->outHandle );
+    // midiOutClose() returns MIDIERR_STILLPLAYING while buffers are still
+    // queued, and in that case the handle is NOT closed. The midiOutReset()
+    // that would retire them is deliberately disabled above, so give the
+    // driver a bounded time to finish rather than dropping the handle.
+    const DWORD start = GetTickCount();
+    MMRESULT result;
+    for ( ;; ) {
+      result = midiOutClose( data->outHandle );
+      if ( result != MIDIERR_STILLPLAYING || GetTickCount() - start >= kWinMMBufferReleaseTimeoutMs ) break;
+      Sleep( 1 );
+    }
     data->outHandle = 0;
+    data->sysexInProgress = false;
     connected_ = false;
+
+    // Reported once the object is back in a consistent state, and as a
+    // warning rather than an error: closePort() also runs from the
+    // destructor, where a thrown RtMidiError would terminate the process.
+    if ( result != MMSYSERR_NOERROR ) {
+      errorString_ = "MidiOutWinMM::closePort: error closing Windows MM MIDI output port (MMRESULT " +
+                     std::to_string( result ) + "); the handle may have leaked.";
+      error( RtMidiError::WARNING, errorString_ );
+    }
   }
 }
 
@@ -3148,11 +3220,46 @@ void MidiOutWinMM :: sendMessage( const unsigned char *message, size_t size )
 
   MMRESULT result;
   WinMidiData *data = static_cast<WinMidiData *> (apiData_);
-  if ( nBytes > 3 ) { // Sysex message
 
-    // Allocate buffer for sysex data.
+  // Decide whether this buffer belongs on the long-message (SysEx) path.
+  //
+  // Routing on length alone is wrong: a caller may hand a large SysEx to
+  // sendMessage() in several spans so it can pace the transfer, and the final
+  // span is frequently short - often a bare 0xF7. Under a size-only test that
+  // tail took the midiOutShortMsg() branch, which must not be used for SysEx,
+  // so the remaining bytes never reached the device and the transfer never
+  // completed. Track the SysEx state instead, so a continuation is routed by
+  // what it is rather than by how big it happens to be.
+  bool isSysex = data->sysexInProgress || message[0] == 0xF0;
+  if ( !isSysex && nBytes > 3 ) isSysex = true;
+
+  if ( isSysex ) {
+
+    // Work out the framing state this buffer leaves behind, but commit it only
+    // once midiOutLongMsg() has accepted the bytes (below). If the send fails,
+    // the state stays as it was, so a caller that retries the same span gets
+    // it routed the same way; otherwise a retried tail of 1-3 bytes would drop
+    // to midiOutShortMsg() and be lost again. Real-time bytes (0xF8-0xFF) may
+    // be interleaved mid-SysEx without ending it; 0xF7 ends it, and so does
+    // any other non-real-time status byte.
+    bool nextSysexInProgress = data->sysexInProgress;
+    for ( unsigned int i=0; i<nBytes; ++i ) {
+      const unsigned char b = message[i];
+      if ( b >= 0xF8 ) continue;
+      if ( b == 0xF0 ) { nextSysexInProgress = true; continue; }
+      if ( b == 0xF7 ) { nextSysexInProgress = false; continue; }
+      if ( b >= 0x80 ) nextSysexInProgress = false;
+    }
+
+    // Allocate the MIDIHDR and its buffer on the heap. Once
+    // midiOutPrepareHeader() succeeds the driver holds pointers to both, so
+    // the failure exits below that may leave the driver owning them leak both
+    // on purpose. Leaking only the buffer is not enough: a stack MIDIHDR would
+    // be reused as soon as this function returned (#377).
+    MIDIHDR *sysex = new MIDIHDR();
     char *buffer = (char *) malloc( nBytes );
     if ( buffer == NULL ) {
+      delete sysex;
       errorString_ = "MidiOutWinMM::sendMessage: error allocating sysex message memory!";
       error( RtMidiError::MEMORY_ERROR, errorString_ );
       return;
@@ -3161,36 +3268,79 @@ void MidiOutWinMM :: sendMessage( const unsigned char *message, size_t size )
     // Copy data to buffer.
     for ( unsigned int i=0; i<nBytes; ++i ) buffer[i] = message[i];
 
-    // Create and prepare MIDIHDR structure.
-    MIDIHDR sysex{};
-    sysex.lpData = (LPSTR) buffer;
-    sysex.dwBufferLength = nBytes;
-    sysex.dwFlags = 0;
-    result = midiOutPrepareHeader( data->outHandle,  &sysex, sizeof( MIDIHDR ) );
+    sysex->lpData = (LPSTR) buffer;
+    sysex->dwBufferLength = nBytes;
+    sysex->dwFlags = 0;
+    result = midiOutPrepareHeader( data->outHandle, sysex, sizeof( MIDIHDR ) );
     if ( result != MMSYSERR_NOERROR ) {
+      // Nothing was handed to the driver, so both can be freed.
       free( buffer );
-      errorString_ = "MidiOutWinMM::sendMessage: error preparing sysex header.";
+      delete sysex;
+      errorString_ = "MidiOutWinMM::sendMessage: error preparing sysex header (MMRESULT " +
+                     std::to_string( result ) + ").";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
     }
 
-    // Send the message.
-    result = midiOutLongMsg( data->outHandle, &sysex, sizeof( MIDIHDR ) );
+    // Send the message. From here on, free only what the driver has provably
+    // released, i.e. only after midiOutUnprepareHeader() succeeds.
+    result = midiOutLongMsg( data->outHandle, sysex, sizeof( MIDIHDR ) );
     if ( result != MMSYSERR_NOERROR ) {
-      free( buffer );
-      errorString_ = "MidiOutWinMM::sendMessage: error sending sysex message.";
+      if ( midiOutUnprepareHeader( data->outHandle, sysex, sizeof( MIDIHDR ) ) == MMSYSERR_NOERROR ) {
+        free( buffer );
+        delete sysex;
+      } // else deliberately leaked: the driver may still hold them
+      errorString_ = "MidiOutWinMM::sendMessage: error sending sysex message (MMRESULT " +
+                     std::to_string( result ) + ").";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
     }
+
+    // The driver has accepted the bytes, so the framing state moves on, even
+    // if releasing the buffer fails below.
+    data->sysexInProgress = nextSysexInProgress;
 
     // Unprepare the buffer and MIDIHDR.
-    while ( MIDIERR_STILLPLAYING == midiOutUnprepareHeader( data->outHandle, &sysex, sizeof ( MIDIHDR ) ) ) Sleep( 1 );
+    //
+    // midiOutUnprepareHeader() returns MIDIERR_STILLPLAYING while the driver
+    // is not yet done with the buffer, which is the one result worth retrying.
+    // Two things matter here: the retry has to be bounded, because how eagerly
+    // a driver retires a buffer is not something this library can probe for
+    // (third-party MIDI drivers are still supported on Windows); and any other
+    // non-zero result has to be treated as a failure rather than as a reason to
+    // fall out of the loop and free a buffer the driver may still own. Surprise
+    // device removal part-way through a long dump reaches exactly that path.
+    //
+    // The bound is a deadline rather than an iteration count: Sleep( 1 ) sleeps
+    // for at least one scheduler tick, ~15.6 ms by default, so counting 1 ms
+    // iterations would overshoot the intended bound many times over.
+    const DWORD start = GetTickCount();
+    for ( ;; ) {
+      result = midiOutUnprepareHeader( data->outHandle, sysex, sizeof ( MIDIHDR ) );
+      if ( result == MMSYSERR_NOERROR ) break;
+      if ( result != MIDIERR_STILLPLAYING ) {
+        errorString_ = "MidiOutWinMM::sendMessage: error unpreparing sysex header (MMRESULT " +
+                       std::to_string( result ) + "); buffer not freed.";
+        error( RtMidiError::DRIVER_ERROR, errorString_ );
+        return; // deliberately leaked: the driver may still hold them
+      }
+      if ( GetTickCount() - start >= kWinMMBufferReleaseTimeoutMs ) {
+        errorString_ = "MidiOutWinMM::sendMessage: timed out waiting for the driver to "
+                       "release the sysex buffer; buffer not freed.";
+        error( RtMidiError::DRIVER_ERROR, errorString_ );
+        return; // deliberately leaked, same reason
+      }
+      Sleep( 1 );
+    }
     free( buffer );
+    delete sysex;
   }
   else { // Channel or system message.
 
-    // Pack MIDI bytes into double word.
-    DWORD packet;
+    // Pack MIDI bytes into double word. Value-initialize: only nBytes of the
+    // four are written, and midiOutShortMsg() should not be handed
+    // indeterminate bytes even though it documents the unused ones as ignored.
+    DWORD packet = 0;
     unsigned char *ptr = (unsigned char *) &packet;
     for ( unsigned int i=0; i<nBytes; ++i ) {
       *ptr = message[i];
@@ -3200,7 +3350,8 @@ void MidiOutWinMM :: sendMessage( const unsigned char *message, size_t size )
     // Send the message immediately.
     result = midiOutShortMsg( data->outHandle, packet );
     if ( result != MMSYSERR_NOERROR ) {
-      errorString_ = "MidiOutWinMM::sendMessage: error sending MIDI message.";
+      errorString_ = "MidiOutWinMM::sendMessage: error sending MIDI message (MMRESULT " +
+                     std::to_string( result ) + ").";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
     }
   }

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -499,6 +499,11 @@ class RTMIDI_DLL_PUBLIC RtMidiOut : public RtMidi
   /*!
       An exception is thrown if an error occurs during output or an
       output connection was not previously established.
+
+      On some backends, Windows MM in particular, a SysEx message is sent
+      synchronously: this call does not return until the driver has finished
+      with the data, which for a large dump over a slow link can take a
+      noticeable amount of time. Avoid calling it from a user-interface thread.
   */
   void sendMessage( const std::vector<unsigned char> *message );
 
@@ -506,6 +511,11 @@ class RTMIDI_DLL_PUBLIC RtMidiOut : public RtMidi
   /*!
       An exception is thrown if an error occurs during output or an
       output connection was not previously established.
+
+      On some backends, Windows MM in particular, a SysEx message is sent
+      synchronously: this call does not return until the driver has finished
+      with the data, which for a large dump over a slow link can take a
+      noticeable amount of time. Avoid calling it from a user-interface thread.
 
       \param message A pointer to the MIDI message as raw bytes
       \param size    Length of the MIDI message in bytes


### PR DESCRIPTION
Five defects in the WinMM backend, all reachable when sending or receiving large SysEx — firmware updates and patch banks. Rebased onto current `master`.

## Output: SysEx routed by framing state, not length (#373)

`sendMessage()` chose between `midiOutLongMsg()` and `midiOutShortMsg()` on `nBytes > 3` alone. A caller pacing a large SysEx across several calls frequently ends with a short span — often a bare `F7` — and that tail took the short-message branch, which must not be used for SysEx. The remaining bytes never reached the device and the transfer never completed.

`WinMidiData` now tracks whether a SysEx is open, so a continuation is routed by what it is rather than by how big it happens to be. The new state is committed only once `midiOutLongMsg()` has accepted the bytes, so a failed send leaves it untouched and a retry of the same span routes identically.

## Output: buffer and header lifetime (#377)

- The `MIDIHDR` and its buffer are heap-allocated. Once `midiOutPrepareHeader()` succeeds the driver holds pointers to both, so any exit that may leave it owning them leaks both deliberately. Leaking only the buffer was not enough — a stack `MIDIHDR` is reused the moment the function returns.
- `midiOutLongMsg()` failure unprepares before freeing, and frees only if the unprepare succeeded.
- The unprepare retry is bounded by a 5 s deadline. Any non-`MIDIERR_STILLPLAYING` result is a failure rather than a reason to fall out of the loop and free a buffer the driver may still own — which is the path surprise device removal during a long dump takes.
- The bound is a `GetTickCount()` deadline rather than an iteration count: `Sleep(1)` sleeps for at least one scheduler tick, ~15.6 ms by default, so counting 1 ms iterations overshoots badly.
- `closePort()` no longer discards `midiOutClose()`'s result, and the short-message `DWORD` is value-initialized.

## Input: closePort teardown (#376, #325)

`MidiInWinMM::closePort()` could return part-way through with the critical section still held, `connected_` still true and the sysex buffers already freed, so the destructor ran the same loop again over deleted pointers.

Teardown now lives in one helper shared by `closePort()` and every `openPort()` failure path. Every step runs regardless of earlier failures, nothing returns early, a header the driver will not release is leaked rather than freed, the vector is cleared, and the first failure is reported after cleanup — as a warning, since `closePort()` also runs from the destructor where a thrown `RtMidiError` would terminate the process. The headers are `new MIDIHDR()` / `delete` rather than the mismatched `new char[]` / `delete[]`.

**Repro, without a firmware update:** hold an input port open on any device, disable it in Device Manager, then close the port. On `master` the process dies with `0xC0000409`; with this PR it reports `MIDIERR_STILLPLAYING` as a warning, leaks the buffer the driver still owns, and exits cleanly. Also note `master`'s message in that path says `MidiInWinMM::openPort:` while running in `closePort()`, which sends anyone reading a user's log to the wrong function; that is corrected here.

## Input: the reopen flag (side effect of #372)

#372 added `std::atomic<bool> closing`, set in `closePort()` and cleared only in `initialize()`. `openPort()` never clears it, so a second `openPort()` on the same `RtMidiIn` runs with it still set, `midiInputCallback()` never requeues, and SysEx input stops once the buffers queued by `openPort()` are consumed — short messages keep working. Measured on hardware: 8 identity requests per open gives 8/8 on the first open and 4/8 on every open after it, 4 being the default `bufferCount`. The shared teardown helper clears the flag, so this PR fixes it as a side effect.

## Open-path error codes (#234)

Five failure paths in `MidiInWinMM::openPort()` and `MidiOutWinMM::openPort()` had an `MMRESULT` in scope and discarded it, so callers got "error creating Windows MM MIDI input port" with nothing to act on. They now report the code, as @SpotlightKid asked for in that thread. This does not change what can be opened — the original report is Windows' exclusive-open behaviour (refs #102) — but it makes the difference between a busy device, a missing one and a driver fault visible.

## Credit

The deadlock between `closePort()` and `midiInputCallback()` was found first by @jkeller51 in #372, which is now merged. This PR previously carried its own fix for the same race; that has been dropped in favour of his, and the branch rebased on top.

## Verification

Builds clean on MSVC x64 and Win32 (`/W4`) and MinGW GCC 16.1.0 UCRT x86_64 (`-Wall -Wextra`), with upstream's test programs. Hardware checks on Windows 11 against a KMI 12 Step, WinMM backend, each run as an A/B against unmodified `master`:

- **#373:** a 6-byte identity request split 4+2, 3+3, 2+2+2 and 1×6 fails on `master` (`sendMessage` error, no reply) and passes on this branch. Whole-message and 5+1 splits pass on both — the bug needs a trailing span of 3 bytes or fewer, which is why it went unnoticed.
- **#376:** the Device Manager repro above — crash on `master`, clean exit here.
- **Reopen:** 4/8 sysex replies after the second `openPort()` on `master`, 8/8 here.

## Scope

Fixes #373. Fixes #376. Fixes #325. Fixes #377. Addresses #234. Refs #333 — the same unbounded unprepare loop, now bounded, but the follow-up there says a timeout alone did not stop the hang and part of that crash was likely #376, so this is not claimed as a fix.

The `midiInAddBuffer`-from-inside-the-callback redesign raised in #376 is left for separate work, as is #375 (UWP). Adds a documentation note that SysEx sends are synchronous on WinMM.
