### PR TITLE
CoreMIDI: replace variable-length array with std::vector

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1686,9 +1686,9 @@ void MidiOutCore :: sendMessage( const unsigned char *message, size_t size )
   OSStatus result;
 
   ByteCount bufsize = nBytes > 65535 ? 65535 : nBytes;
-  Byte buffer[bufsize+16]; // pad for other struct members
-  ByteCount listSize = sizeof( buffer );
-  MIDIPacketList *packetList = (MIDIPacketList*)buffer;
+  std::vector<Byte> buffer( bufsize + 16 ); // pad for other struct members
+  ByteCount listSize = buffer.size();
+  MIDIPacketList *packetList = (MIDIPacketList*)buffer.data();
 
   ByteCount remainingBytes = nBytes;
   while ( remainingBytes ) {


### PR DESCRIPTION
`MidiOutCore::sendMessage()` allocates its `MIDIPacketList` backing store as a variable-length array:

```cpp
ByteCount bufsize = nBytes > 65535 ? 65535 : nBytes;
Byte buffer[bufsize+16]; // pad for other struct members
ByteCount listSize = sizeof( buffer );
MIDIPacketList *packetList = (MIDIPacketList*)buffer;
```

VLAs are not standard C++ — Clang warns under `-Wvla-cxx-extension` and MSVC rejects them outright. `bufsize` is also caller-derived, up to 64K + 16, which is more than is comfortable to place on the stack.

This uses a `std::vector<Byte>` instead, taking `listSize` from the vector and pointing `packetList` at `data()`. Behaviour is unchanged: the buffer is still allocated once and reused across every iteration of the chunking loop.

## Relationship to PR #350

PR #350 proposes `alloca()` for the same warning. That keeps the allocation on the stack, avoiding a heap allocation in the send path, but `alloca()` is non-standard and unbounded for a large SysEx; `std::vector` is portable and heap-safe.

Both fix the warning. **The choice is yours** — if you prefer the `alloca()` approach, this should be dropped in favour of #350, which was filed first.

## Verification

macOS, Clang: compiles clean, no warnings.

Tested against real MIDI 2.0 hardware (MIDI-CI Discovery, Property Exchange Get of a 1129-byte resource list, a 366-byte multi-chunk PE Get with reassembly, and PE Set plus verify) — byte-identical results to the unpatched baseline.

The buffer-reuse loop across the 64K chunking boundary was exercised specifically, since that is the only part this change could plausibly break: a 70000-byte payload through `MidiOutCore::sendMessage()` over a virtual CoreMIDI port pair round-tripped 70002/70002 bytes byte-identical, `F0`..`F7` intact.

Addresses #350.